### PR TITLE
HYP-155 Fix inconsistent units

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.1.24",
+    "version": "0.1.25",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/sqnc-hyproof-client",
-            "version": "0.1.24",
+            "version": "0.1.25",
             "license": "Apache-2.0",
             "dependencies": {
                 "@digicatapult/ui-component-library": "^0.17.25",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.1.23",
+    "version": "0.1.24",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/sqnc-hyproof-client",
-            "version": "0.1.23",
+            "version": "0.1.24",
             "license": "Apache-2.0",
             "dependencies": {
                 "@digicatapult/ui-component-library": "^0.17.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.1.24",
+    "version": "0.1.25",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/sqnc-hyproof-client",
     "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.1.23",
+    "version": "0.1.24",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/sqnc-hyproof-client",
     "main": "src/index.js",

--- a/src/pages/components/CertificateInputFields.js
+++ b/src/pages/components/CertificateInputFields.js
@@ -22,86 +22,84 @@ export default function CertificateInputFields({
   handleSzChgeVal,
 }) {
   return (
-    <>
-      <PaddedDiv>
-        <ContainerFlexWrapDiv>
-          <FlexLargeDiv>
-            <ContainerFlexNoWrapDiv>
-              <GrowingDiv>
-                <InputHeadingDiv>Start timestamp of energy use</InputHeadingDiv>
-                <InputWrapLeftDiv>
-                  <InputHalfWrap>
-                    <InputFieldDate
-                      val={sdVal}
-                      onChangeVal={handleSdChgeVal}
-                      name="sd"
-                    />
-                  </InputHalfWrap>
-                  <InputHalfWrap>
-                    <InputFieldTime
-                      val={stVal}
-                      onChangeVal={handleStChgeVal}
-                      name="st"
-                    />
-                  </InputHalfWrap>
-                </InputWrapLeftDiv>
-              </GrowingDiv>
-              <CertificateTimeInterval
-                sTimestamp={`${sdVal} ${stVal}`}
-                eTimestamp={`${edVal} ${etVal}`}
-              />
-              <GrowingDiv>
-                <InputHeadingDiv>End timestamp of energy use</InputHeadingDiv>
-                <InputWrapRightDiv>
-                  <InputHalfWrap>
-                    <InputFieldDate
-                      val={edVal}
-                      onChangeVal={handleEdChgeVal}
-                      name="ed"
-                    />
-                  </InputHalfWrap>
-                  <InputHalfWrap>
-                    <InputFieldTime
-                      val={etVal}
-                      onChangeVal={handleEtChgeVal}
-                      name="et"
-                    />
-                  </InputHalfWrap>
-                </InputWrapRightDiv>
-              </GrowingDiv>
-            </ContainerFlexNoWrapDiv>
-          </FlexLargeDiv>
-          <FlexDiv>
-            <ContainerFullWidthWrapDiv>
-              <InputHeadingDiv>Electric energy use</InputHeadingDiv>
-              <InputWrapDiv>
-                <InputWrap>
-                  <InputFieldEnergy
-                    val={enVal}
-                    onChangeVal={handleEnChgeVal}
-                    name="en"
+    <PaddedDiv>
+      <ContainerFlexWrapDiv>
+        <FlexLargeDiv>
+          <ContainerFlexNoWrapDiv>
+            <GrowingDiv>
+              <InputHeadingDiv>Start timestamp of energy use</InputHeadingDiv>
+              <InputWrapLeftDiv>
+                <InputHalfWrap>
+                  <InputFieldDate
+                    val={sdVal}
+                    onChangeVal={handleSdChgeVal}
+                    name="sd"
                   />
-                </InputWrap>
-              </InputWrapDiv>
-            </ContainerFullWidthWrapDiv>
-          </FlexDiv>
-          <FlexDiv>
-            <ContainerFullWidthWrapDiv>
-              <InputHeadingDiv>H2 batch size</InputHeadingDiv>
-              <InputWrapDiv>
-                <InputWrap>
-                  <InputFieldSize
-                    val={szVal}
-                    onChangeVal={handleSzChgeVal}
-                    name="sz"
+                </InputHalfWrap>
+                <InputHalfWrap>
+                  <InputFieldTime
+                    val={stVal}
+                    onChangeVal={handleStChgeVal}
+                    name="st"
                   />
-                </InputWrap>
-              </InputWrapDiv>
-            </ContainerFullWidthWrapDiv>
-          </FlexDiv>
-        </ContainerFlexWrapDiv>
-      </PaddedDiv>
-    </>
+                </InputHalfWrap>
+              </InputWrapLeftDiv>
+            </GrowingDiv>
+            <CertificateTimeInterval
+              sTimestamp={`${sdVal} ${stVal}`}
+              eTimestamp={`${edVal} ${etVal}`}
+            />
+            <GrowingDiv>
+              <InputHeadingDiv>End timestamp of energy use</InputHeadingDiv>
+              <InputWrapRightDiv>
+                <InputHalfWrap>
+                  <InputFieldDate
+                    val={edVal}
+                    onChangeVal={handleEdChgeVal}
+                    name="ed"
+                  />
+                </InputHalfWrap>
+                <InputHalfWrap>
+                  <InputFieldTime
+                    val={etVal}
+                    onChangeVal={handleEtChgeVal}
+                    name="et"
+                  />
+                </InputHalfWrap>
+              </InputWrapRightDiv>
+            </GrowingDiv>
+          </ContainerFlexNoWrapDiv>
+        </FlexLargeDiv>
+        <FlexDiv>
+          <ContainerFullWidthWrapDiv>
+            <InputHeadingDiv>Electric energy use</InputHeadingDiv>
+            <InputWrapDiv>
+              <InputWrap>
+                <InputFieldEnergy
+                  val={enVal}
+                  onChangeVal={handleEnChgeVal}
+                  name="en"
+                />
+              </InputWrap>
+            </InputWrapDiv>
+          </ContainerFullWidthWrapDiv>
+        </FlexDiv>
+        <FlexDiv>
+          <ContainerFullWidthWrapDiv>
+            <InputHeadingDiv>H2 batch size</InputHeadingDiv>
+            <InputWrapDiv>
+              <InputWrap>
+                <InputFieldSize
+                  val={szVal}
+                  onChangeVal={handleSzChgeVal}
+                  name="sz"
+                />
+              </InputWrap>
+            </InputWrapDiv>
+          </ContainerFullWidthWrapDiv>
+        </FlexDiv>
+      </ContainerFlexWrapDiv>
+    </PaddedDiv>
   )
 }
 

--- a/src/pages/components/CertificateViewDetails.js
+++ b/src/pages/components/CertificateViewDetails.js
@@ -73,7 +73,7 @@ export default function CertificateViewDetails({
           <FlexDiv>
             <ContainerFullWidthWrapDiv>
               <HeadingDiv>Electric energy use</HeadingDiv>
-              <WrapShortDiv>{energy / 1000000} kWh</WrapShortDiv>
+              <WrapShortDiv>{energy / 1000000} MWh</WrapShortDiv>
             </ContainerFullWidthWrapDiv>
           </FlexDiv>
         )}
@@ -81,7 +81,7 @@ export default function CertificateViewDetails({
           <FlexDiv>
             <ContainerFullWidthWrapDiv>
               <HeadingDiv>H2 batch size</HeadingDiv>
-              <WrapShortDiv>{size / 1000000} kWh</WrapShortDiv>
+              <WrapShortDiv>{size / 1000000} MWh</WrapShortDiv>
             </ContainerFullWidthWrapDiv>
           </FlexDiv>
         )}

--- a/src/pages/components/InputFieldEnergy.js
+++ b/src/pages/components/InputFieldEnergy.js
@@ -11,7 +11,7 @@ export default function InputFieldEnergy({ val, onChangeVal, name }) {
         name={name}
         value={val}
         onChange={(e) => onChangeVal(e)}
-        placeholder="0.0 kWh"
+        placeholder="0.0 MWh"
         list={id}
       />
       <datalist id={id}>

--- a/src/pages/components/InputFieldSize.js
+++ b/src/pages/components/InputFieldSize.js
@@ -11,7 +11,7 @@ export default function InputFieldSize({ val, onChangeVal, name }) {
         name={name}
         value={val}
         onChange={(e) => onChangeVal(e)}
-        placeholder="0.0 kWh"
+        placeholder="0.0 MWh"
         list={id}
       />
       <datalist id={id}>


### PR DESCRIPTION
---
name: Fix inconsistent units
about: Fixing the inconsistency when it comes to units
---

### Prerequisites

- [x] Checked the FAQs for common solutions: <https://github.com/digicatapult/sqnc-hyproof-client/blob/main/CONTRIBUTING.md/#FAQs>
- [x] Checked that your issue isn't already filed: <https://github.com/issues?utf8=✓&q=is%3Aissue+user%3Asqnc-hyproof-client>

### Description

There seem to a small inconsistency when it comes to units for measuring the electricity used for producing the batch and the batch quantity itself. The unit **MWh** needs to be present everywhere.

This is in connection to the Jira ticket **HYP-155**

### Steps to Reproduce

1. Fill in the for and check how the placeholder and the drop down looks like
2. When finishing check the unit on the certificate

**Expected behaviour:**

The unit MWh should be present _everywhere_

**Actual behaviour:**

In some cases we have kWh and in some kWh

### Versions

NA

### Additional Information

Screenshots

![image](https://github.com/digicatapult/sqnc-hyproof-client/assets/58742260/99ce0f04-372c-4448-9201-ecacad32ebb3)

![image](https://github.com/digicatapult/sqnc-hyproof-client/assets/58742260/754b8bfd-ef4c-4c05-9720-b7c3e4cb4820)
