### PR TITLE
HYP-147: Heidi's certificate list view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.1.25",
+    "version": "0.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/sqnc-hyproof-client",
-            "version": "0.1.25",
+            "version": "0.2.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@digicatapult/ui-component-library": "^0.17.25",
+                "@digicatapult/ui-component-library": "^0.18.0",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-id-generator": "^3.0.2",
@@ -1838,13 +1838,13 @@
             }
         },
         "node_modules/@digicatapult/ui-component-library": {
-            "version": "0.17.30",
-            "resolved": "https://registry.npmjs.org/@digicatapult/ui-component-library/-/ui-component-library-0.17.30.tgz",
-            "integrity": "sha512-DAkHTBYwRIodO73T4wFkRv/96444j423G2v+7GBKsryrYXHUvKrvvzIFr2R+YY+gGWXpQVqdWSXK++APo2l79Q==",
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/@digicatapult/ui-component-library/-/ui-component-library-0.18.0.tgz",
+            "integrity": "sha512-Y/Cq4Zr4gJ/6MzxeySdTdr1sxZ0I7AVM7kL0+v4YLkDX7QtELm2FI7njeklpbAkbXiAPRLq8BFNhQY0qI1ao+w==",
             "dependencies": {
                 "geojson": "^0.5.0",
                 "jsqr": "^1.4.0",
-                "mapbox-gl": "^3.1.2",
+                "mapbox-gl": "^3.2.0",
                 "moo": "^0.5.2",
                 "react-id-generator": "^3.0.2",
                 "react-select": "^5.8.0",
@@ -2339,9 +2339,9 @@
             }
         },
         "node_modules/@mapbox/mapbox-gl-supported": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-2.0.1.tgz",
-            "integrity": "sha512-HP6XvfNIzfoMVfyGjBckjiAOQK9WfX0ywdLubuPMPv+Vqf5fj0uCbgBQYpiqcWZT6cbyyRnTSXDheT1ugvF6UQ=="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-3.0.0.tgz",
+            "integrity": "sha512-2XghOwu16ZwPJLOFVuIOaLbN0iKMn867evzXFyf0P22dqugezfJwLmdanAgU25ITvz1TvOfVP4jsDImlDJzcWg=="
         },
         "node_modules/@mapbox/point-geometry": {
             "version": "0.1.0",
@@ -7799,6 +7799,11 @@
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
+        "node_modules/lodash.clonedeep": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+            "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+        },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -7853,13 +7858,13 @@
             }
         },
         "node_modules/mapbox-gl": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.1.2.tgz",
-            "integrity": "sha512-+KoLEqZM8GxO/ViPz9tKgGURteKne+Y0pXiVCNsowymiZFH3FiL6dt9oZE95owMg5XqD3Kygz5mfchR1ZgmWlA==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.2.0.tgz",
+            "integrity": "sha512-v8S7x+wTr35kJ9nqzgn/VPiSFZxBkyQhwCk9bdyiFHVwCukNGG3LXt03FoaHHTsOuB9JWenWE96k0Uw+HGMZ8w==",
             "dependencies": {
                 "@mapbox/geojson-rewind": "^0.5.2",
                 "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-                "@mapbox/mapbox-gl-supported": "^2.0.1",
+                "@mapbox/mapbox-gl-supported": "^3.0.0",
                 "@mapbox/point-geometry": "^0.1.0",
                 "@mapbox/tiny-sdf": "^2.0.6",
                 "@mapbox/unitbezier": "^0.0.1",
@@ -7872,13 +7877,16 @@
                 "gl-matrix": "^3.4.3",
                 "grid-index": "^1.1.0",
                 "kdbush": "^4.0.1",
+                "lodash.clonedeep": "^4.5.0",
                 "murmurhash-js": "^1.0.0",
                 "pbf": "^3.2.1",
                 "potpack": "^2.0.0",
                 "quickselect": "^2.0.0",
                 "rw": "^1.3.3",
+                "serialize-to-js": "^3.1.2",
                 "supercluster": "^8.0.0",
                 "tinyqueue": "^2.0.3",
+                "tweakpane": "^4.0.3",
                 "vt-pbf": "^3.1.3"
             }
         },
@@ -9732,6 +9740,14 @@
                 "randombytes": "^2.1.0"
             }
         },
+        "node_modules/serialize-to-js": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-3.1.2.tgz",
+            "integrity": "sha512-owllqNuDDEimQat7EPG0tH7JjO090xKNzUtYz6X+Sk2BXDnOCilDdNLwjWeFywG9xkJul1ULvtUQa9O4pUaY0w==",
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
         "node_modules/serve": {
             "version": "14.2.1",
             "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.1.tgz",
@@ -10642,6 +10658,14 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
             "dev": true
+        },
+        "node_modules/tweakpane": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/tweakpane/-/tweakpane-4.0.3.tgz",
+            "integrity": "sha512-BlcWOAe8oe4c+k9pmLBARGdWB6MVZMszayekkixQXTgkxTaYoTUpHpwVEp+3HkoamZkomodpbBf0CkguIHTgLg==",
+            "funding": {
+                "url": "https://github.com/sponsors/cocopon"
+            }
         },
         "node_modules/type-check": {
             "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.1.25",
+    "version": "0.2.0",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/sqnc-hyproof-client",
     "main": "src/index.js",
@@ -72,7 +72,7 @@
         "webpack-dev-server": "^5.0.2"
     },
     "dependencies": {
-        "@digicatapult/ui-component-library": "^0.17.25",
+        "@digicatapult/ui-component-library": "^0.18.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-id-generator": "^3.0.2",

--- a/src/App.js
+++ b/src/App.js
@@ -98,6 +98,7 @@ export default function App() {
             <SidePanel.Item
               {...el}
               key={el.id}
+              active={el.id === current}
               update={(_, persona) => handlePersonaSwitch(persona)}
               variant="hyproof"
             />

--- a/src/hooks/use-axios.js
+++ b/src/hooks/use-axios.js
@@ -37,8 +37,10 @@ export default function useAxios(
       }
     },
     onSuccess: async (res) => {
-      setData(res.data)
       setLoading(false)
+      return res instanceof Error
+        ? setError(res.message)
+        : setData(res.data || res)
     },
     onError: async (error) => {
       setError(error)

--- a/src/pages/CertificatesViewAll.js
+++ b/src/pages/CertificatesViewAll.js
@@ -74,7 +74,9 @@ export default function CertificatesViewAll() {
               />,
               `${cert.hydrogen_quantity_wh / 1000000} MWh`,
               `${cert.energy_consumed_wh / 1000000} MWh`,
-              cert?.embodied_co2 ? `${cert.embodied_co2 / 1000} g CO2e` : '',
+              cert?.embodied_co2
+                ? `${(cert.embodied_co2 / 1000).toFixed(1)} Kg CO2e`
+                : '',
               stateToStatus[checkCO2(cert)],
             ])}
             variant="hyproof"

--- a/src/pages/CertificatesViewAll.js
+++ b/src/pages/CertificatesViewAll.js
@@ -74,7 +74,7 @@ export default function CertificatesViewAll() {
               />,
               `${cert.hydrogen_quantity_wh / 1000000} MWh`,
               `${cert.energy_consumed_wh / 1000000} MWh`,
-              cert?.embodied_co2 ? `${cert.embodied_co2} g CO2e` : '',
+              cert?.embodied_co2 ? `${cert.embodied_co2 / 1000} g CO2e` : '',
               stateToStatus[checkCO2(cert)],
             ])}
             variant="hyproof"

--- a/src/pages/CertificatesViewAll.js
+++ b/src/pages/CertificatesViewAll.js
@@ -1,69 +1,93 @@
 import React, { useContext } from 'react'
 import styled from 'styled-components'
-import { Grid } from '@digicatapult/ui-component-library'
+import { Grid, Spinner, Table } from '@digicatapult/ui-component-library'
 
 import Nav from './components/Nav'
 import Header from './components/Header'
 
 import { Context } from '../utils/Context'
+import { stateToStatus, NameCell } from './components/shared'
 import { personas } from '../App'
+import { useNavigate } from 'react-router-dom'
+import useAxios from '../hooks/use-axios'
+
+const headersMap = {
+  heidi: [
+    'Date',
+    'H2 Batch size',
+    'Electric energy use',
+    'Carbon Embodiment',
+    'Status',
+  ],
+  emma: ['Date', 'Commitment'],
+  reginald: [],
+}
 
 export default function CertificatesViewAll() {
   const { current } = useContext(Context)
+  const { data, loading, error, callApiFn: fetch } = useAxios()
+  const navigate = useNavigate()
+
   const persona = personas.find(({ id }) => id === current)
+  const url = `${persona.origin}/v1/certificate`
+
+  React.useEffect(() => {
+    if (!data) fetch({ url })
+  }, [data, fetch, url])
+
   return (
     <>
       <Nav />
-      <Header userFullName={persona.name} companyName={persona.company} />
-      <LeftWrapper area="timeline"></LeftWrapper>
-      <MainWrapper>
-        <Grid.Panel area="main">
-          <Container>
-            <Text>
-              Certificates View All: <br />
-              Certificate One <br />
-              Certificate Two <br />
-              ...
-            </Text>
-          </Container>
-        </Grid.Panel>
-        <Sidebar area="sidebar"></Sidebar>
-      </MainWrapper>
+      <Header
+        userFullName={persona.name}
+        companyName={error || persona.company}
+      />
+      <Timeline area="timeline"></Timeline>
+      <Main area="main">
+        {(loading || error) && (
+          <Spinner
+            text={error || 'loading...'}
+            size={'large'}
+            color={persona.background}
+          />
+        )}
+        {data && (
+          <Table
+            action={(item) =>
+              navigate(`/certificate/${item.original_token_id}`)
+            }
+            headers={headersMap[current]}
+            rows={data.map((cert) => [
+              /* TODO with other cert viewing stories
+                  - create rows/cels per persona using "headersMap as an example"*/
+              <NameCell
+                key={cert.id}
+                date={new Date(cert.created_at).toISOString()}
+                name={`SQNC-HYPROOF-${cert.original_token_id.toString().padStart(4, '0')}`}
+              />,
+              `${cert.hydrogen_quantity_wh}`,
+              `${cert.energy_consumed_wh}`,
+              `${cert.embodied_co2}`,
+              stateToStatus[(cert.embodied_co2 && 'co2') || cert.state],
+            ])}
+            variant="hyproof"
+          />
+        )}
+        {data?.length === 0 && 'nothing to render'}
+      </Main>
     </>
   )
 }
 
-const LeftWrapper = styled(Grid.Panel)`
-  max-width: 400px;
-  max-height: 100%;
-  padding: 20px 0px;
-  overflow: hidden;
-  background: #0c3b38;
+const Timeline = styled(Grid.Panel)`
+  background: rgb(39, 132, 122);
 `
 
-const MainWrapper = styled.div`
-  display: grid;
-  grid: subgrid / subgrid;
-  grid-area: 2 / 1 / -1 / -1;
-  overflow: hidden;
-  text-align: center;
-`
-
-const Sidebar = styled(Grid.Panel)`
-  align-items: center;
-  justify-items: center;
-  min-width: 340px;
-  color: white;
-  background: #0c3b38;
-`
-
-const Container = styled.div`
-  display: grid;
+const Main = styled(Grid.Panel)`
+  background: rgb(39, 132, 122);
+  color: #fff;
+  width: 100%;
+  align-self: center;
   height: 100%;
-  grid-area: 1 / 1 / -1 / -1;
-`
-
-const Text = styled.h1`
-  margin: auto 5px;
-  text-align: center;
+  padding: 28px;
 `

--- a/src/pages/components/shared.js
+++ b/src/pages/components/shared.js
@@ -1,5 +1,103 @@
 import styled from 'styled-components'
+import React from 'react'
 
+import {
+  CertificateCO2Icon,
+  CertificateIssuedIcon,
+  CertificatePendingIcon,
+  CertificateRevokedIcon,
+  PadlockIcon,
+  ClockIcon,
+} from '@digicatapult/ui-component-library'
+
+export const NameCell = ({ name, date }) => (
+  <Col>
+    <Row>
+      <PadlockIcon />
+      <Title>{name}</Title>
+    </Row>
+    <Row>
+      <ClockIcon />
+      <Date>{date}</Date>
+    </Row>
+  </Col>
+)
+
+export const StatusCell = ({ color = '#27847a', Icon, status }) => (
+  <Col>
+    <Icon />
+    <Status color={color}>{status}</Status>
+  </Col>
+)
+
+export const stateToStatus = {
+  pending: <StatusCell Icon={CertificatePendingIcon} status={'Pending'} />,
+  initiated: <StatusCell Icon={CertificatePendingIcon} status={'Pending'} />,
+  issued: <StatusCell Icon={CertificateIssuedIcon} status={'Issued'} />,
+  revoked: (
+    <StatusCell
+      Icon={CertificateRevokedIcon}
+      status={'Revoked'}
+      color={'red'}
+    />
+  ),
+  cancelled: (
+    <StatusCell
+      Icon={CertificateRevokedIcon}
+      status={'Cancelled'}
+      color={'red'}
+    />
+  ),
+  co2: <StatusCell Icon={CertificateCO2Icon} status={'C.Embodiment'} />,
+}
+
+const Title = styled('div')`
+  color: #6aa685;
+  font-family: Roboto;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 0px; /* 0% */
+`
+
+const Status = styled('div')`
+  width: 90px;
+  background-color: ${(props) => props.color || '#27847a'};
+  color: #fff;
+  border-radius: 60px;
+
+  text-align: center;
+  font-family: Roboto;
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 10px; /* 83.333% */
+`
+
+const Date = styled('div')`
+  color: #27847a;
+
+  font-family: Roboto;
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 10px; /* 83.333% */
+`
+
+const Row = styled('div')`
+  display: flex;
+  flex-direction: row;
+  gap: 5px;
+  align-items: center;
+`
+
+const Col = styled('div')`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  gap: 5px;
+`
 export const TimelineDisclaimer = styled('div')`
   padding: 50px 20px;
   color: #33e58c;

--- a/src/pages/components/shared.js
+++ b/src/pages/components/shared.js
@@ -32,7 +32,7 @@ export const StatusCell = ({ color = '#27847a', Icon, status }) => (
 
 export const stateToStatus = {
   pending: <StatusCell Icon={CertificatePendingIcon} status={'Pending'} />,
-  initiated: <StatusCell Icon={CertificatePendingIcon} status={'Pending'} />,
+  initiated: <StatusCell Icon={CertificatePendingIcon} status={'Initiated'} />,
   issued: <StatusCell Icon={CertificateIssuedIcon} status={'Issued'} />,
   revoked: (
     <StatusCell
@@ -68,10 +68,9 @@ const Status = styled('div')`
 
   text-align: center;
   font-family: Roboto;
-  font-size: 12px;
-  font-style: normal;
+  font-size: 10px;
   font-weight: 400;
-  line-height: 10px; /* 83.333% */
+  line-height: 12px; /* 83.333% */
 `
 
 const Date = styled('div')`
@@ -79,7 +78,6 @@ const Date = styled('div')`
 
   font-family: Roboto;
   font-size: 12px;
-  font-style: normal;
   font-weight: 400;
   line-height: 10px; /* 83.333% */
 `
@@ -87,16 +85,16 @@ const Date = styled('div')`
 const Row = styled('div')`
   display: flex;
   flex-direction: row;
+  font-family: Roboto;
   gap: 5px;
   align-items: center;
 `
 
 const Col = styled('div')`
   display: flex;
-  justify-content: center;
   align-items: center;
   flex-direction: column;
-  gap: 5px;
+  gap: 10px;
 `
 export const TimelineDisclaimer = styled('div')`
   padding: 50px 20px;

--- a/src/utils/Router.js
+++ b/src/utils/Router.js
@@ -33,6 +33,7 @@ export default function Routes() {
               <Route path=":id" element={<CertificateViewer />} />
             </Route>
             <Route path="*" element={<Error404 />} />
+            <Route path="/certificates" element={<CertificatesViewAll />} />
           </>
         )
       )}


### PR DESCRIPTION
# What

Adding table component and page for viewing certificatges along with some bug fixes ... to be updated for time being please refer to the screenshots

## bugfixes
- display current persona (active) in the side bar
- multiple useAxios hook updates, for standard usage e.g. GET req
- some other styling minors

## changes
- reused current component CertificateViewAll 
- some functiins around formatting
- table:)
- please refer to screenshots

## New Screenshots
<img width="1581" alt="Screenshot 2024-03-06 at 10 00 18 am" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/11794402/f610282c-47f6-4e2a-8415-9bdabfff08f8">
<img width="1708" alt="Screenshot 2024-03-06 at 10 00 09 am" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/11794402/528c916a-7ac7-4eb4-89c5-136ef8d50b95">
<img width="1611" alt="Screenshot 2024-03-06 at 10 00 05 am" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/11794402/837aa934-3c7a-43e3-b695-e3741cb3529a">
<img width="1728" alt="Screenshot 2024-03-06 at 9 55 55 am" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/11794402/fddebeb3-5d25-4b8c-9b30-fd391445eb97">
<img width="1177" alt="Screenshot 2024-03-06 at 9 48 49 am" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/11794402/68c5d705-dbb8-4cc0-9eba-a1b2731ea018">
<img width="1086" alt="Screenshot 2024-03-06 at 9 48 43 am" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/11794402/ae65025e-4564-400c-a9d3-d7918d4a72c3">



### OLD Screenshots
<img width="1264" alt="Screenshot 2024-03-06 at 7 25 30 am" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/11794402/54a995fc-7d56-4d6f-9bdc-532033a5181b">
<img width="1728" alt="Screenshot 2024-03-06 at 7 15 59 am" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/11794402/978ad9a5-4142-4cbf-a4eb-ffe152ced29e">

<img width="1689" alt="Screenshot 2024-03-06 at 7 13 35 am" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/11794402/38ccbe90-9ea4-425a-863a-0187845c309c">
<img width="1721" alt="Screenshot 2024-03-06 at 7 13 20 am" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/11794402/0ab92185-3327-43f8-b334-22a3ba238e15">
<img width="1727" alt="Screenshot 2024-03-06 at 7 12 23 am" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/11794402/07188047-4cb3-48c2-9580-430f0eb1c7f5">
<img width="488" alt="Screenshot 2024-03-06 at 7 13 55 am" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/11794402/f760148b-b58f-4fe5-be7f-0147fdd40333">
<img width="480" alt="Screenshot 2024-03-06 at 7 13 53 am" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/11794402/fe799403-3e99-4da6-99d3-15af6a52fec1">
<img width="363" alt="Screenshot 2024-03-06 at 7 13 38 am" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/11794402/ebca480f-4f84-4a0c-b767-916c253d952d">
<img width="1689" alt="Screenshot 2024-03-06 at 7 13 35 am" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/11794402/658322d3-615f-4193-8d87-751f7dff9d87">

<img width="1724" alt="Screenshot 2024-03-06 at 7 16 27 am" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/11794402/664608f0-dbd6-4c62-b48e-e13b097835b4">
<img width="1728" alt="Screenshot 2024-03-06 at 7 15 59 am" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/11794402/66d38d63-daeb-43de-970b-50f0304f20a8">

<img width="442" alt="Screenshot 2024-03-06 at 7 14 00 am" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/11794402/0dbc7ffd-3e18-4120-8382-c184da32ef78">
<img width="459" alt="Screenshot 2024-03-06 at 7 13 57 am" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/11794402/18d1feb0-65eb-4d71-93e3-30dfe24f4076">



