### PR TITLE
Chore/inprove resize styling part 1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/sqnc-hyproof-client",
-            "version": "0.2.2",
+            "version": "0.2.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "@digicatapult/ui-component-library": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/sqnc-hyproof-client",
     "main": "src/index.js",

--- a/src/App.js
+++ b/src/App.js
@@ -76,34 +76,61 @@ export default function App() {
 
   return (
     <QueryClientProvider client={new QueryClient()}>
+      <SidePanel
+        width={400}
+        variant="hyproof"
+        heading="Certificate View"
+        title={persona.name}
+        callback={(e) => setShowSelector(e.isOpen)}
+      >
+        {personas.map((el) => (
+          <SidePanel.Item
+            {...el}
+            key={el.id}
+            active={el.id === current}
+            update={(_, persona) => handlePersonaSwitch(persona)}
+            variant="hyproof"
+          />
+        ))}
+      </SidePanel>
       <FullScreenGrid
         color={persona.background}
         showSelector={showSelector}
         areas={[
-          ['home', 'nav', 'nav'],
-          ['header', 'header', 'sidebar'],
-          ['timeline', 'main', 'sidebar'],
+          ['home', 'nav'],
+          ['header', 'header'],
+          ['timeline', 'main'],
+          ['timeline', 'sidebar'],
         ]}
-        columns={['auto', '1fr', 'auto']}
-        rows={['78px', '98px', '1fr']}
+        columns={['minmax(min-content, 1fr)', '2fr']}
+        rows={['78px', '98px', '1fr', 'auto']}
+        byWidth={[
+          {
+            minWidth: 1000,
+            areas: [
+              ['home', 'nav', 'nav'],
+              ['header', 'header', 'sidebar'],
+              ['timeline', 'main', 'sidebar'],
+            ],
+            columns: [
+              'minmax(min-content, 1.5fr)',
+              '4fr',
+              'minmax(min-content, 1.5fr)',
+            ],
+            rows: ['78px', '98px', '1fr'],
+          },
+          {
+            minWidth: 1500,
+            areas: [
+              ['home', 'nav', 'nav'],
+              ['header', 'header', 'sidebar'],
+              ['timeline', 'main', 'sidebar'],
+            ],
+            columns: ['320px', '1fr', '320px'],
+            rows: ['78px', '98px', '1fr'],
+          },
+        ]}
       >
-        <SidePanel
-          width={400}
-          variant="hyproof"
-          heading="Certificate View"
-          title={persona.name}
-          callback={(e) => setShowSelector(e.isOpen)}
-        >
-          {personas.map((el) => (
-            <SidePanel.Item
-              {...el}
-              key={el.id}
-              active={el.id === current}
-              update={(_, persona) => handlePersonaSwitch(persona)}
-              variant="hyproof"
-            />
-          ))}
-        </SidePanel>
         <Routes />
       </FullScreenGrid>
     </QueryClientProvider>
@@ -117,12 +144,10 @@ const FullScreenGrid = styled(Grid)`
   margin-left: ${({ showSelector }) => (showSelector ? '450px' : '0px')};
   overflow: hidden;
   box-sizing: border-box;
-  background-color: ${({ showSelector, color }) =>
-    showSelector ? color : 'white'};
   transition:
-    background-color ease 0.1s,
     width ease-in-out 0.7s,
-    padding ease-in-out 0.7s,
+    border ease-in-out 0.7s,
     margin-left ease-in-out 0.7s;
-  padding: ${({ showSelector }) => (showSelector ? '20px' : '0px')};
+  border: ${({ showSelector, color }) =>
+    `${showSelector ? '20px' : '0px'} solid ${color}`};
 `

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -217,12 +217,10 @@ export default function CertificateViewer() {
 }
 
 const LeftWrapper = styled(Grid.Panel)`
-  max-width: 400px;
   max-height: 100%;
   padding: 20px 0px;
   overflow: hidden;
   background: #0c3b38;
-  width: 400px;
 `
 
 const MainWrapper = styled.div`
@@ -236,19 +234,17 @@ const MainWrapper = styled.div`
 const Sidebar = styled(Grid.Panel)`
   align-items: center;
   justify-items: center;
-  min-width: 340px;
+
   color: white;
   background: #0c3b38;
 `
 
 const ContainerDiv = styled.div`
   display: grid;
-  height: 100%;
   grid-area: 1 / 1 / -1 / -1;
   background: #228077 url(${BgMoleculesImageSVG}) repeat;
   background-size: 100px;
   padding: 34px;
-  height: 100%;
   align-content: start;
 `
 

--- a/src/pages/Error404.js
+++ b/src/pages/Error404.js
@@ -36,7 +36,6 @@ const MainWrapper = styled.div`
 
 const Container = styled.div`
   display: grid;
-  height: 100%;
   grid-area: 1 / 1 / -1 / -1;
 `
 

--- a/src/pages/components/CertificateActionsButtons.js
+++ b/src/pages/components/CertificateActionsButtons.js
@@ -21,43 +21,20 @@ export default function CertificateActionsButtons({
   return (
     <Sidebar area="sidebar">
       <PaddedDiv>
-        <Grid
-          areas={[
-            ['div-left', 'div-right'],
-            ['div-double', 'div-double'],
-          ]}
-          rows={['40px', '60px']}
-          columns={['1fr', '1fr']}
-          gap="20px 10px"
-        >
-          <Grid.Panel area="div-left">
-            <SmallButton
-              variant="roundedPronounced"
-              onClick={handleClickSaveDraft}
-            >
-              Save draft
-            </SmallButton>
-          </Grid.Panel>
-          <Grid.Panel area="div-right">
-            <SmallButton
-              variant="roundedPronounced"
-              onClick={handleCancelDraft}
-            >
-              Cancel
-            </SmallButton>
-          </Grid.Panel>
-          <Grid.Panel area="div-double">
-            <LargeButton
-              disabled={loading || !valid}
-              variant="roundedPronounced"
-            >
-              {loading == false && data == null && <Span>Submit</Span>}
-              {loading == false && data != null && <Span>Submitted</Span>}
-              {loading && <AnimatedSpan>...</AnimatedSpan>}
-              {error && <Span>Error</Span>}
-            </LargeButton>
-          </Grid.Panel>
-        </Grid>
+        <SmallButton variant="roundedPronounced" onClick={handleClickSaveDraft}>
+          Save draft
+        </SmallButton>
+
+        <SmallButton variant="roundedPronounced" onClick={handleCancelDraft}>
+          Cancel
+        </SmallButton>
+
+        <LargeButton disabled={loading || !valid} variant="roundedPronounced">
+          {loading == false && data == null && <Span>Submit</Span>}
+          {loading == false && data != null && <Span>Submitted</Span>}
+          {loading && <AnimatedSpan>...</AnimatedSpan>}
+          {error && <Span>Error</Span>}
+        </LargeButton>
       </PaddedDiv>
     </Sidebar>
   )
@@ -66,41 +43,45 @@ export default function CertificateActionsButtons({
 const Sidebar = styled(Grid.Panel)`
   align-items: center;
   justify-items: center;
-  min-width: 340px;
   color: white;
   background: #0c3b38;
 `
 
 const PaddedDiv = styled.div`
-  padding: 34px 21px;
   width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 34px 21px;
 `
 
 const SmallButton = styled(Button)`
-  width: 100%;
-  min-width: 132px;
-  height: 100% !important;
+  flex: 1 0 110px;
+  min-height: 40px;
+  display: block;
   font-family: Roboto;
   font-style: normal;
   font-weight: 500;
   white-space: nowrap;
   font-size: 15.5px;
   color: #ffffff;
-  border: 1px solid #ffffff !important;
-  background: #124338 !important;
+  border: 1px solid #ffffff;
+  background: #124338;
   &:hover {
     opacity: 0.6;
   }
 `
 
 const LargeButton = styled(SmallButton)`
+  min-width: 100%;
+  min-height: 60px;
   font-size: 21px;
   color: #33e58c;
-  border: 1px solid #2fe181 !important;
-  background: #124338 !important;
+  border: 1px solid #2fe181;
+  background: #124338;
   &:disabled {
     color: #1c774a;
-    border: 1px solid #1c774a !important;
+    border: 1px solid #1c774a;
   }
 `
 

--- a/src/pages/components/CertificateCo2Post.js
+++ b/src/pages/components/CertificateCo2Post.js
@@ -196,7 +196,6 @@ export default function CertificateCo2Post() {
 }
 
 const LeftWrapper = styled(Grid.Panel)`
-  max-width: 400px;
   max-height: 100%;
   padding: 20px 0px;
   overflow: hidden;
@@ -214,7 +213,6 @@ const MainWrapper = styled.div`
 const Sidebar = styled(Grid.Panel)`
   align-items: center;
   justify-items: center;
-  min-width: 340px;
   color: white;
   background: #0c3b38;
 `

--- a/src/pages/components/CertificateForm.js
+++ b/src/pages/components/CertificateForm.js
@@ -206,7 +206,6 @@ const Form = styled.form`
 `
 
 const TimelineWrapper = styled(Grid.Panel)`
-  max-width: 400px;
   max-height: 100%;
   padding: 20px 0px;
   overflow: hidden;

--- a/src/pages/components/CertificateInputFields.js
+++ b/src/pages/components/CertificateInputFields.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
+import { Grid } from '@digicatapult/ui-component-library'
 
 import CertificateTimeInterval from './CertificateTimeInterval'
 import InputFieldDate from './InputFieldDate'
@@ -24,10 +25,23 @@ export default function CertificateInputFields({
   return (
     <PaddedDiv>
       <ContainerFlexWrapDiv>
-        <FlexLargeDiv>
-          <ContainerFlexNoWrapDiv>
-            <GrowingDiv>
-              <InputHeadingDiv>Start timestamp of energy use</InputHeadingDiv>
+        <FlexDiv>
+          <Grid
+            areas={[
+              ['label_start', '-', 'label_end'],
+              ['inputs_start', 'interval', 'inputs_end'],
+            ]}
+            columns={[
+              'minmax(min-content, 1fr)',
+              'auto',
+              'minmax(min-content, 1fr)',
+            ]}
+            rows={['auto', 'auto']}
+          >
+            <Grid.Panel area="label_start">
+              <InputHeadingDiv>Start of energy use</InputHeadingDiv>
+            </Grid.Panel>
+            <Grid.Panel area="inputs_start">
               <InputWrapLeftDiv>
                 <InputHalfWrap>
                   <InputFieldDate
@@ -44,13 +58,15 @@ export default function CertificateInputFields({
                   />
                 </InputHalfWrap>
               </InputWrapLeftDiv>
-            </GrowingDiv>
+            </Grid.Panel>
             <CertificateTimeInterval
               sTimestamp={`${sdVal} ${stVal}`}
               eTimestamp={`${edVal} ${etVal}`}
             />
-            <GrowingDiv>
-              <InputHeadingDiv>End timestamp of energy use</InputHeadingDiv>
+            <Grid.Panel area="label_end">
+              <InputHeadingDiv>End of energy use</InputHeadingDiv>
+            </Grid.Panel>
+            <Grid.Panel area="inputs_end">
               <InputWrapRightDiv>
                 <InputHalfWrap>
                   <InputFieldDate
@@ -67,36 +83,32 @@ export default function CertificateInputFields({
                   />
                 </InputHalfWrap>
               </InputWrapRightDiv>
-            </GrowingDiv>
-          </ContainerFlexNoWrapDiv>
-        </FlexLargeDiv>
-        <FlexDiv>
-          <ContainerFullWidthWrapDiv>
-            <InputHeadingDiv>Electric energy use</InputHeadingDiv>
-            <InputWrapDiv>
-              <InputWrap>
-                <InputFieldEnergy
-                  val={enVal}
-                  onChangeVal={handleEnChgeVal}
-                  name="en"
-                />
-              </InputWrap>
-            </InputWrapDiv>
-          </ContainerFullWidthWrapDiv>
+            </Grid.Panel>
+          </Grid>
         </FlexDiv>
         <FlexDiv>
-          <ContainerFullWidthWrapDiv>
-            <InputHeadingDiv>H2 batch size</InputHeadingDiv>
-            <InputWrapDiv>
-              <InputWrap>
-                <InputFieldSize
-                  val={szVal}
-                  onChangeVal={handleSzChgeVal}
-                  name="sz"
-                />
-              </InputWrap>
-            </InputWrapDiv>
-          </ContainerFullWidthWrapDiv>
+          <InputHeadingDiv>Electric energy use</InputHeadingDiv>
+          <InputWrapDiv>
+            <InputWrap>
+              <InputFieldEnergy
+                val={enVal}
+                onChangeVal={handleEnChgeVal}
+                name="en"
+              />
+            </InputWrap>
+          </InputWrapDiv>
+        </FlexDiv>
+        <FlexDiv>
+          <InputHeadingDiv>H2 batch size</InputHeadingDiv>
+          <InputWrapDiv>
+            <InputWrap>
+              <InputFieldSize
+                val={szVal}
+                onChangeVal={handleSzChgeVal}
+                name="sz"
+              />
+            </InputWrap>
+          </InputWrapDiv>
         </FlexDiv>
       </ContainerFlexWrapDiv>
     </PaddedDiv>
@@ -104,47 +116,35 @@ export default function CertificateInputFields({
 }
 
 const PaddedDiv = styled.div`
+  max-width: 900px;
+  margin-inline: auto;
   padding: 8px;
-  height: 100%;
   background: white;
 `
 
 const ContainerFlexWrapDiv = styled.div`
   display: flex;
   flex-wrap: wrap;
-`
-
-const ContainerFlexNoWrapDiv = styled.div`
-  display: flex;
-  flex-wrap: nowrap;
+  gap: 15px;
 `
 
 const FlexDiv = styled.div`
-  margin: 8px 8px 45px 8px;
-  height: 110px;
-  line-height: 110px;
-  min-width: 270px;
   flex-grow: 1;
-`
-
-const FlexLargeDiv = styled(FlexDiv)`
-  min-width: 556px;
 `
 
 const InputHeadingDiv = styled.div`
   color: #1a1a1a;
-  height: 28px;
-  font: 500 15px/28px Roboto;
+  font: 500 15px Roboto;
+  padding-top: 12px;
+  padding-bottom: 8px;
 `
 
 const InputWrapDiv = styled.div`
-  height: 82px;
-  line-height: 82px;
   display: flex;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   border: 1px solid #a9a9a9;
   border-radius: 10px 10px 10px 10px;
-  padding: 15px 0;
+  padding: 10px;
 `
 
 const InputWrapLeftDiv = styled(InputWrapDiv)`
@@ -171,7 +171,6 @@ const InputWrap = styled.div`
 `
 
 const InputHalfWrap = styled.div`
-  width: 50%;
   height: 52px;
   line-height: 52px;
   display: flex;

--- a/src/pages/components/CertificateInputFields.js
+++ b/src/pages/components/CertificateInputFields.js
@@ -155,14 +155,6 @@ const InputWrapRightDiv = styled(InputWrapDiv)`
   border-radius: 0 10px 10px 0px;
 `
 
-const ContainerFullWidthWrapDiv = styled.div`
-  width: 100%;
-`
-
-const GrowingDiv = styled.div`
-  flex-grow: 1;
-`
-
 const InputWrap = styled.div`
   width: 100%;
   display: block;

--- a/src/pages/components/CertificateTimeInterval.js
+++ b/src/pages/components/CertificateTimeInterval.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
+import { Grid } from '@digicatapult/ui-component-library'
 
 import StartEndSpacerSVG from '../../assets/images/start-end-spacer-bg.svg'
 
@@ -38,20 +39,21 @@ export default function CertificateTimeInterval({
   bgColor,
 }) {
   return (
-    <FixedWidthSmallDiv bg={bgColor}>
+    <FixedWidthSmallDiv area="interval" bg={bgColor}>
       {convIntervalToStr(sTimestamp, eTimestamp)}
     </FixedWidthSmallDiv>
   )
 }
 
-const FixedWidthSmallDiv = styled.div`
-  width: 98px;
-  height: 82px;
-  margin-top: 28px;
-  text-align: center;
+const FixedWidthSmallDiv = styled(Grid.Panel)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 100px;
   color: #67a8a1;
-  font: 500 14px/82px Roboto;
+  font: 500 14px Roboto;
   background-image: url(${StartEndSpacerSVG});
+  background-position: center;
   background-color: ${({ bg }) => (bg === 'white' ? '#ffffff' : '#27847a')};
   background-repeat: no-repeat;
 `

--- a/src/pages/components/Header.js
+++ b/src/pages/components/Header.js
@@ -38,7 +38,6 @@ const StyledHeader = styled(Grid.Panel)`
   align-items: center;
   background: #1a1a1a;
   width: 100%;
-  height: 100%;
   padding: 0px 28px;
 `
 

--- a/src/pages/components/InputFieldDate.js
+++ b/src/pages/components/InputFieldDate.js
@@ -52,7 +52,6 @@ const Input = styled.input.attrs({ type: 'date' })`
     top: unset;
     left: unset;
     width: 100%;
-    height: 100%;
     background: transparent;
     color: transparent;
     z-index: 1;

--- a/src/pages/components/InputFieldTime.js
+++ b/src/pages/components/InputFieldTime.js
@@ -52,7 +52,6 @@ const Input = styled.input.attrs({ type: 'time' })`
     top: unset;
     left: unset;
     width: 100%;
-    height: 100%;
     background: transparent;
     color: transparent;
     z-index: 1;

--- a/src/pages/components/Nav.js
+++ b/src/pages/components/Nav.js
@@ -24,7 +24,6 @@ export default function Nav() {
         >
           <AppBar.Item>what we do</AppBar.Item>
           <AppBar.Item active={true}>certificates</AppBar.Item>
-          <AppBar.Item>contact us</AppBar.Item>
         </AppBar>
       </Grid.Panel>
     </>


### PR DESCRIPTION
Improves styling on the new certificate form on resizing. A few examples

4k:

![Screenshot 2024-03-07 at 11 25 16](https://github.com/digicatapult/sqnc-hyproof-client/assets/29942957/c887bf67-35e0-4b56-aeff-dcc4a5dcb7d2)

1200px:

![Screenshot 2024-03-07 at 11 26 11](https://github.com/digicatapult/sqnc-hyproof-client/assets/29942957/217bdd1b-336c-45c9-a91f-9e1157081d1b)

800px:

![Screenshot 2024-03-07 at 11 27 00](https://github.com/digicatapult/sqnc-hyproof-client/assets/29942957/228c1168-e02d-4085-b156-08f03282e43a)

Note there's more improvements to come, this is just a starter
