### PR TITLE
HYP 169 Unnecessary 2 Sec Delay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/sqnc-hyproof-client",
-            "version": "0.2.3",
+            "version": "0.2.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "@digicatapult/ui-component-library": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/sqnc-hyproof-client",
     "main": "src/index.js",

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -61,7 +61,10 @@ export default function CertificateViewer() {
       setPosting(true)
       await new Promise((resolve) => setTimeout(resolve, 1000))
       const hasCo2 = foundCert?.embodied_co2 !== null
-      if (hasCo2) return
+      if (hasCo2) {
+        setPosting(false)
+        return
+      }
       const foundCertHash = foundCert?.commitment
       const {
         currentCommitment: hash,

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -109,13 +109,21 @@ export default function CertificateViewer() {
     if (curPersona === 'emma') {
       fetchLatestCert().then((c) => {
         co2PostIfNeeded(c).then(() => {
-          intervalId = setInterval(async () => {
-            const latestCert = await fetchLatestCert()
+          fetchLatestCert().then((latestCert) => {
             if (JSON.stringify(latestCert) != JSON.stringify(buffer.current)) {
               buffer.current = latestCert
               setData(latestCert)
+              intervalId = setInterval(async () => {
+                const latestCert = await fetchLatestCert()
+                if (
+                  JSON.stringify(latestCert) != JSON.stringify(buffer.current)
+                ) {
+                  buffer.current = latestCert
+                  setData(latestCert)
+                }
+              }, 9 * 1000)
             }
-          }, 2 * 1000)
+          })
         })
       })
     }

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -118,14 +118,21 @@ export default function CertificateViewer() {
       })
 
     // Start fetch loop ( fetch every few secs ) if not Emma
-    curPersona !== 'emma' &&
-      (intervalId = setInterval(async () => {
-        const latestCert = await fetchLatestCert()
+    if (curPersona !== 'emma') {
+      fetchLatestCert().then(async (latestCert) => {
         if (JSON.stringify(latestCert) != JSON.stringify(buffer.current)) {
           buffer.current = latestCert
           setData(latestCert)
+          intervalId = setInterval(async () => {
+            const latestCert = await fetchLatestCert()
+            if (JSON.stringify(latestCert) != JSON.stringify(buffer.current)) {
+              buffer.current = latestCert
+              setData(latestCert)
+            }
+          }, 2 * 1000)
         }
-      }, 2 * 1000))
+      })
+    }
 
     // Cleanup the interval on unmount
     return () => {

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -59,7 +59,6 @@ export default function CertificateViewer() {
       let url, body
 
       setPosting(true)
-      await new Promise((resolve) => setTimeout(resolve, 1000))
       const hasCo2 = foundCert?.embodied_co2 !== null
       if (hasCo2) {
         setPosting(false)
@@ -123,7 +122,7 @@ export default function CertificateViewer() {
 
     // Start fetch loop ( fetch every few secs ) if not Emma
     if (curPersona !== 'emma') {
-      fetchLatestCert().then(async (latestCert) => {
+      fetchLatestCert().then((latestCert) => {
         if (JSON.stringify(latestCert) != JSON.stringify(buffer.current)) {
           buffer.current = latestCert
           setData(latestCert)

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -107,7 +107,7 @@ export default function CertificateViewer() {
     }
 
     // If Emma then post co2 if it hasn't got co2 (no embedded co2 from fetch) then start fetch loop
-    curPersona === 'emma' &&
+    if (curPersona === 'emma') {
       fetchLatestCert().then((c) => {
         co2PostIfNeeded(c).then(() => {
           intervalId = setInterval(async () => {
@@ -119,6 +119,7 @@ export default function CertificateViewer() {
           }, 2 * 1000)
         })
       })
+    }
 
     // Start fetch loop ( fetch every few secs ) if not Emma
     if (curPersona !== 'emma') {


### PR DESCRIPTION
---
name: Unnecessary 2 Sec Delay
about: Unnecessary 2 second delay when loading certificate
---

### Prerequisites

- [x] Checked the FAQs for common solutions: <https://github.com/digicatapult/sqnc-hyproof-client/blob/main/CONTRIBUTING.md/#FAQs>
- [x] Checked that your issue isn't already filed: <https://github.com/issues?utf8=✓&q=is%3Aissue+user%3Asqnc-hyproof-client>

### Description

When opening the certificate view page ( view a single certificate ) , e.g.: `/certificate/1` there is 2 sec delay.

This is connected to the Jira ticket **HYP-169**.

### Steps to Reproduce

1. Run
2. Fill in the form and add at least 1 cert
3. View it

**Expected behaviour:**

No delay

**Actual behaviour:**

A delay of 2 seconds

**Reproduces how often:**

Always

### Versions

NA

### Additional Information

This also fixes a bug .. This bug shows when switching view to Emma ( from another persona )

![image](https://github.com/digicatapult/sqnc-hyproof-client/assets/58742260/f5a2ccfe-1e11-49e3-9996-8e613473ebf0)

Before:

<img width="1346" alt="image" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/58742260/74b8b062-ab6f-40a4-b473-be33d529e894">

After: no delay

![output](https://github.com/digicatapult/sqnc-hyproof-client/assets/58742260/cd204580-6543-448b-9a67-7d1a884a55d2)


