### PR TITLE
HYP 171 Connor and Reginald Do Not Have Names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/sqnc-hyproof-client",
-            "version": "0.2.3",
+            "version": "0.2.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "@digicatapult/ui-component-library": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/sqnc-hyproof-client",
     "main": "src/index.js",


### PR DESCRIPTION
---
name: Connor and Reginald Do Not Have Names
about: Connor and Reginald don't have names in the title bar
---

### Prerequisites

- [x] Checked the FAQs for common solutions: <https://github.com/digicatapult/sqnc-hyproof-client/blob/main/CONTRIBUTING.md/#FAQs>
- [x] Checked that your issue isn't already filed: <https://github.com/issues?utf8=✓&q=is%3Aissue+user%3Asqnc-hyproof-client>

### Description

Heidi and Emma have their names in the title bar. Connor and Reginald do not.

This is related to the Jira ticket **HYP-171**.


### Steps to Reproduce

1. Run
2. Inspect the side bar (click the gray arrow on the left top)

**Expected behaviour:**

Connor and Reginald should have names right next to the logo

**Actual behaviour:**

Connor and Reginald don't have names

**Reproduces how often:**

Always

### Versions

NA

### Additional Information

Heidi and Emma have their names in the title bar

Connor and Reginald do not

