### PR TITLE
Feat/hyp 159 navbar changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/sqnc-hyproof-client",
-            "version": "0.3.0",
+            "version": "0.3.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@digicatapult/ui-component-library": "^0.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/sqnc-hyproof-client",
-            "version": "0.3.1",
+            "version": "0.3.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@digicatapult/ui-component-library": "^0.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/sqnc-hyproof-client",
-            "version": "0.3.2",
+            "version": "0.3.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "@digicatapult/ui-component-library": "^0.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/sqnc-hyproof-client",
     "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/sqnc-hyproof-client",
     "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/sqnc-hyproof-client",
     "main": "src/index.js",

--- a/src/App.js
+++ b/src/App.js
@@ -41,7 +41,7 @@ export const personas = [
     name: 'Connor Connor',
     title: 'Connor Connor',
     subtitle: 'The Hydrogen Consumer',
-    company: "Conor's Consuming LTD",
+    company: "Connor's Consuming LTD",
     background: '#FDB6D4',
     origin: 'http://localhost:8020',
   },

--- a/src/pages/CertificatesViewAll.js
+++ b/src/pages/CertificatesViewAll.js
@@ -1,9 +1,13 @@
 import React, { useContext } from 'react'
 import styled from 'styled-components'
-import { Grid, Spinner, Table } from '@digicatapult/ui-component-library'
+import {
+  Grid,
+  Spinner,
+  Table,
+  Button,
+} from '@digicatapult/ui-component-library'
 
 import { Link } from 'react-router-dom'
-import { Button } from '@digicatapult/ui-component-library'
 
 import Nav from './components/Nav'
 import Header from './components/Header'
@@ -97,10 +101,10 @@ export default function CertificatesViewAll() {
 }
 
 const Sidebar = styled(Grid.Panel)`
+  background: #0c3b38;
   align-items: center;
   justify-items: center;
   color: white;
-  background: #0c3b38;
   gap: 10px;
   padding: 34px 21px;
 `

--- a/src/pages/CertificatesViewAll.js
+++ b/src/pages/CertificatesViewAll.js
@@ -133,10 +133,7 @@ const PaddedDiv = styled.div`
 const LargeButton = styled(Button)`
   min-height: 60px;
   width: 100%;
-  font-family: Roboto;
-  font-style: normal;
-  font-weight: 500;
-  font-size: 21px;
+  font: normal 500 21px Roboto;
   white-space: nowrap;
   color: #33e58c;
   border: 1px solid #2fe181;

--- a/src/pages/CertificatesViewAll.js
+++ b/src/pages/CertificatesViewAll.js
@@ -88,11 +88,9 @@ export default function CertificatesViewAll() {
         {data?.length === 0 && 'nothing to render'}
       </Main>
       <Sidebar area="sidebar">
-        <PaddedDiv>
-          <LargeButton variant="roundedPronounced">
-            <Link to="/certificate?create=y">New Certificate</Link>
-          </LargeButton>
-        </PaddedDiv>
+        <LargeButton variant="roundedPronounced">
+          <Link to="/certificate?create=y">New Certificate</Link>
+        </LargeButton>
       </Sidebar>
     </>
   )
@@ -103,6 +101,8 @@ const Sidebar = styled(Grid.Panel)`
   justify-items: center;
   color: white;
   background: #0c3b38;
+  gap: 10px;
+  padding: 34px 21px;
 `
 
 const Main = styled.div`
@@ -121,13 +121,6 @@ const Main = styled.div`
     margin-inline: auto;
     max-width: 1200px;
   }
-`
-
-const PaddedDiv = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  padding: 34px 21px;
 `
 
 const LargeButton = styled(Button)`

--- a/src/pages/CertificatesViewAll.js
+++ b/src/pages/CertificatesViewAll.js
@@ -2,6 +2,9 @@ import React, { useContext } from 'react'
 import styled from 'styled-components'
 import { Grid, Spinner, Table } from '@digicatapult/ui-component-library'
 
+import { Link } from 'react-router-dom'
+import { Button } from '@digicatapult/ui-component-library'
+
 import Nav from './components/Nav'
 import Header from './components/Header'
 import BgMoleculesImageSVG from '../assets/images/molecules-bg-repeat.svg'
@@ -84,12 +87,21 @@ export default function CertificatesViewAll() {
         )}
         {data?.length === 0 && 'nothing to render'}
       </Main>
-      <Sidebar area="sidebar"></Sidebar>
+      <Sidebar area="sidebar">
+        <PaddedDiv>
+          <LargeButton variant="roundedPronounced">
+            <Link to="/certificate?create=y">New Certificate</Link>
+          </LargeButton>
+        </PaddedDiv>
+      </Sidebar>
     </>
   )
 }
 
 const Sidebar = styled(Grid.Panel)`
+  align-items: center;
+  justify-items: center;
+  color: white;
   background: #0c3b38;
 `
 
@@ -108,5 +120,36 @@ const Main = styled.div`
   & > * {
     margin-inline: auto;
     max-width: 1200px;
+  }
+`
+
+const PaddedDiv = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 34px 21px;
+`
+
+const LargeButton = styled(Button)`
+  min-height: 60px;
+  width: 100%;
+  font-family: Roboto;
+  font-style: normal;
+  font-weight: 500;
+  font-size: 21px;
+  white-space: nowrap;
+  color: #33e58c;
+  border: 1px solid #2fe181;
+  background: #124338;
+  &:hover {
+    opacity: 0.6;
+  }
+  &:disabled {
+    color: #1c774a;
+    border: 1px solid #1c774a;
+  }
+  & a {
+    color: #33e58c;
+    text-decoration: none;
   }
 `

--- a/src/pages/components/Nav.js
+++ b/src/pages/components/Nav.js
@@ -1,13 +1,11 @@
-import React from 'react'
-import { useRef } from 'react'
+import React, { useRef } from 'react'
 import styled from 'styled-components'
 
 import { Link } from 'react-router-dom'
 
 import LogoSVG from '../../assets/images/hii-logo.svg'
 
-import { Grid, AppBar } from '@digicatapult/ui-component-library'
-import { Dialog } from '@digicatapult/ui-component-library'
+import { Grid, AppBar, Dialog } from '@digicatapult/ui-component-library'
 
 export default function Nav() {
   const path = window.location.pathname

--- a/src/pages/components/Nav.js
+++ b/src/pages/components/Nav.js
@@ -32,19 +32,6 @@ export default function Nav() {
             accent: '#FFF',
           }}
         >
-          {/* OLD */}
-          {/* <AppBar.Item href="/what-we-do" active={path === '/what-we-do'}>
-            what we do
-          </AppBar.Item> */}
-          {/* <AppBar.Item
-            href="/certificate"
-            active={path.startsWith('/certificate')}
-          >
-            certificates
-          </AppBar.Item> */}
-          {/* OLD END */}
-
-          {/* Inactive app item w/ Link since only Link avoids discarding the context */}
           <AppBar.Item onClick={inactive}>
             <WhiteLink onClick={showPopup}>what we do</WhiteLink>
           </AppBar.Item>
@@ -54,17 +41,6 @@ export default function Nav() {
           >
             <WhiteLink to="/certificate">certificates</WhiteLink>
           </AppBar.Item>
-
-          {/* Alternative */}
-          {/* <AppBar.Item href="." onClick={showPopup}>
-            what we do
-          </AppBar.Item> */}
-          {/* <AppBar.Item
-            href="/certificate"
-            active={path.startsWith('/certificate')}
-          >
-            certificates
-          </AppBar.Item> */}
         </AppBar>
       </Grid.Panel>
       <Dialog width="40ch" margin="20px auto" padding="9px" ref={dialogRef}>

--- a/src/pages/components/Nav.js
+++ b/src/pages/components/Nav.js
@@ -1,12 +1,23 @@
 import React from 'react'
+import { useRef } from 'react'
 import styled from 'styled-components'
+
+import { Link } from 'react-router-dom'
 
 import LogoSVG from '../../assets/images/hii-logo.svg'
 
 import { Grid, AppBar } from '@digicatapult/ui-component-library'
+import { Dialog } from '@digicatapult/ui-component-library'
 
 export default function Nav() {
   const path = window.location.pathname
+
+  const dialogRef = useRef(null)
+  const inactive = (e) => e.preventDefault()
+  const showPopup = (e) => {
+    e.preventDefault()
+    dialogRef.current?.show()
+  }
 
   return (
     <>
@@ -21,17 +32,44 @@ export default function Nav() {
             accent: '#FFF',
           }}
         >
-          <AppBar.Item href="/what-we-do" active={path === '/what-we-do'}>
+          {/* OLD */}
+          {/* <AppBar.Item href="/what-we-do" active={path === '/what-we-do'}>
             what we do
-          </AppBar.Item>
-          <AppBar.Item
+          </AppBar.Item> */}
+          {/* <AppBar.Item
             href="/certificate"
             active={path.startsWith('/certificate')}
           >
             certificates
+          </AppBar.Item> */}
+          {/* OLD END */}
+
+          {/* Inactive app item w/ Link since only Link avoids discarding the context */}
+          <AppBar.Item onClick={inactive}>
+            <WhiteLink onClick={showPopup}>what we do</WhiteLink>
           </AppBar.Item>
+          <AppBar.Item
+            onClick={inactive}
+            active={path.startsWith('/certificate')}
+          >
+            <WhiteLink to="/certificate">certificates</WhiteLink>
+          </AppBar.Item>
+
+          {/* Alternative */}
+          {/* <AppBar.Item href="." onClick={showPopup}>
+            what we do
+          </AppBar.Item> */}
+          {/* <AppBar.Item
+            href="/certificate"
+            active={path.startsWith('/certificate')}
+          >
+            certificates
+          </AppBar.Item> */}
         </AppBar>
       </Grid.Panel>
+      <Dialog width="40ch" margin="20px auto" padding="9px" ref={dialogRef}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      </Dialog>
     </>
   )
 }
@@ -44,4 +82,12 @@ const Home = styled(Grid.Panel)`
   justify-content: space-between;
   padding-left: 20px;
   padding-right: 20px;
+`
+
+const WhiteLink = styled(Link)`
+  color: white;
+  text-decoration: none;
+  &:hover {
+    color: #dbe9e8;
+  }
 `

--- a/src/pages/components/Nav.js
+++ b/src/pages/components/Nav.js
@@ -20,7 +20,9 @@ export default function Nav() {
   return (
     <>
       <Home area="home">
-        <img src={LogoSVG} alt="HII Initiative Logo" height="76px" />
+        <Link to="/">
+          <img src={LogoSVG} alt="HII Initiative Logo" height="76px" />
+        </Link>
       </Home>
       <Grid.Panel area="nav">
         <AppBar

--- a/src/utils/Router.js
+++ b/src/utils/Router.js
@@ -26,7 +26,8 @@ export default function Routes() {
       router={createBrowserRouter(
         createRoutesFromElements(
           <>
-            <Route path="/" element={<Navigate to="/certificate?create=y" />} />
+            {/* <Route path="/" element={<Navigate to="/certificate?create=y" />} /> */}
+            <Route path="/" element={<Navigate to="/certificate" />} />
             <Route path="/certificate" element={<Outlet />}>
               <Route index element={<CreateViewSwitcher />} />
               <Route path=":id" element={<CertificateViewer />} />

--- a/src/utils/Router.js
+++ b/src/utils/Router.js
@@ -26,7 +26,6 @@ export default function Routes() {
       router={createBrowserRouter(
         createRoutesFromElements(
           <>
-            {/* <Route path="/" element={<Navigate to="/certificate?create=y" />} /> */}
             <Route path="/" element={<Navigate to="/certificate" />} />
             <Route path="/certificate" element={<Outlet />}>
               <Route index element={<CreateViewSwitcher />} />


### PR DESCRIPTION
---
name: Navbar Changes
about: HYP 159 Navbar Changes
---

## Summary

This is in connection to Jira ticket number **HYP 159**.

This is adding the following changes:

* Delete Contact Us button ( already covered by previous PR )
* Delete Home button ( already covered by previous PR )
* Link the top navigation bar to different functionalities: What We Do to a pop up;Certificates → Certificate List View.
* Landing page would go to Certificate List View
* For Heidi, she will have an action button on right column, on the certificate list view, to add a certificate New Certificate
* Clicking on the _Logo_ will redirect you to _Home_ ( `/` )

---

## Motivation

To make the React GUI closer to the agreed design

---

## Describe alternatives you've considered

Another option has been considered, which is keeping a simple AppBar item

```jsx
<AppBar>
  <AppBar.Item>
    ...
  </AppBar.Item>
</AppBar>
```

however, this tends to discard context.

Therefore I have added inactive app item w/ **`Link`** since only **`Link`** avoids discarding the context.

```jsx
<AppBar>
  <AppBar.Item>
    <Link>...</Link>
  </AppBar.Item>
</AppBar>
```

---

## Additional context

Screenshots

<img width="1093" alt="image" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/58742260/427d618a-d791-451d-8bf0-c93019208575">

<img width="1667" alt="image" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/58742260/3f93b1f4-e921-405e-98a3-80f0136c17c8">

<img width="308" alt="image" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/58742260/13b2286d-d3ee-4a1b-ac83-65e8c24b15f7">

---
