### PR TITLE
Hyp 175 Grey rectangle issue happening while viewing Co2 viewing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.3.6",
+    "version": "0.3.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/sqnc-hyproof-client",
-            "version": "0.3.6",
+            "version": "0.3.7",
             "license": "Apache-2.0",
             "dependencies": {
                 "@digicatapult/ui-component-library": "^0.19.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.3.6",
+    "version": "0.3.7",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/sqnc-hyproof-client",
     "main": "src/index.js",

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -57,7 +57,10 @@ export default function CertificateViewer() {
       setPosting(true)
 
       const hasCo2 = foundCert?.embodied_co2 !== null
-      if (hasCo2) return
+      if (hasCo2) {
+        setPosting(false)
+        return
+      }
       const foundCertHash = foundCert?.commitment
       const {
         currentCommitment: hash,


### PR DESCRIPTION
---
name: Hyp 175 Grey rectangle issue happening while viewing Co2 viewing
about: Hyp 175 Grey rectangle issue happening while viewing Co2 viewing
---


### Prerequisites

- [x] Checked the FAQs for common solutions: <https://github.com/digicatapult/sqnc-hyproof-client/blob/main/CONTRIBUTING.md/#FAQs>
- [x] Checked that your issue isn't already filed: <https://github.com/issues?utf8=✓&q=is%3Aissue+user%3Asqnc-hyproof-client>

### Description

The rectangle that was supposed to render the Co2 is a grey empty rectangle. This fixes it.

### Steps to Reproduce

1. Post a cert
2. Add Co2 
3. Change views a few times ( from one persona to another , e.g: Emma )

**Expected behaviour:**

Green rectangle w Co2

**Actual behaviour:**

Grey

**Reproduces how often:**

Always

### Versions

N/A

### Additional Information

![image](https://github.com/digicatapult/sqnc-hyproof-client/assets/58742260/f390df5f-033d-4dc1-8374-5e19153458dd)
