### PR TITLE
HYP 167 Cert Issued Timestamp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.3.12",
+    "version": "0.3.13",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/sqnc-hyproof-client",
-            "version": "0.3.12",
+            "version": "0.3.13",
             "license": "Apache-2.0",
             "dependencies": {
                 "@digicatapult/ui-component-library": "^0.19.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.3.11",
+    "version": "0.3.12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/sqnc-hyproof-client",
-            "version": "0.3.11",
+            "version": "0.3.12",
             "license": "Apache-2.0",
             "dependencies": {
                 "@digicatapult/ui-component-library": "^0.19.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.3.14",
+    "version": "0.3.15",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/sqnc-hyproof-client",
-            "version": "0.3.14",
+            "version": "0.3.15",
             "license": "Apache-2.0",
             "dependencies": {
                 "@digicatapult/ui-component-library": "^0.19.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.3.13",
+    "version": "0.3.14",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/sqnc-hyproof-client",
-            "version": "0.3.13",
+            "version": "0.3.14",
             "license": "Apache-2.0",
             "dependencies": {
                 "@digicatapult/ui-component-library": "^0.19.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.3.13",
+    "version": "0.3.14",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/sqnc-hyproof-client",
     "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.3.11",
+    "version": "0.3.12",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/sqnc-hyproof-client",
     "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.3.14",
+    "version": "0.3.15",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/sqnc-hyproof-client",
     "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.3.12",
+    "version": "0.3.13",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/sqnc-hyproof-client",
     "main": "src/index.js",

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -208,6 +208,7 @@ export default function CertificateViewer() {
                     energy={data?.energy_consumed_wh}
                     eco2={data?.embodied_co2}
                     posting={posting}
+                    timestamp={data?.updated_at}
                   />
                 </Grid.Panel>
               </Grid>

--- a/src/pages/components/CertificateViewDetails.js
+++ b/src/pages/components/CertificateViewDetails.js
@@ -27,6 +27,12 @@ export default function CertificateViewDetails({
   return (
     <PaddedWrapperDiv>
       <ContainerFlexWrapDiv>
+        {true == true && (
+          <FullWidthDiv>
+            <GreenText>Timestamp of Certificate Issuance</GreenText>
+            <GreenBoldText>YYYY/MM/DD, HH:MM</GreenBoldText>
+          </FullWidthDiv>
+        )}
         {hasDate(start) && hasDate(end) && (
           <FlexDiv>
             <Grid
@@ -139,6 +145,12 @@ const PaddedWrapperDiv = styled.div`
   min-height: 400px;
 
   text-align: left;
+`
+
+const FullWidthDiv = styled.div`
+  margin: 8px 8px 20px 8px;
+  width: 100%;
+  background: #ededed;
 `
 
 const ContainerFlexWrapDiv = styled.div`
@@ -274,6 +286,14 @@ const IconTime = styled.span`
   width: 26px;
   height: 26px;
   background: transparent url(${BgIconTimeSVG}) no-repeat;
+`
+
+const GreenText = styled.div`
+  //
+`
+
+const GreenBoldText = styled.div`
+  //
 `
 
 const Text = styled.div`

--- a/src/pages/components/CertificateViewDetails.js
+++ b/src/pages/components/CertificateViewDetails.js
@@ -150,7 +150,7 @@ const PaddedWrapperDiv = styled.div`
 const FullWidthDiv = styled.div`
   margin: 8px 8px 20px 8px;
   width: 100%;
-  background: #ededed;
+  // background: #ededed;
 `
 
 const ContainerFlexWrapDiv = styled.div`
@@ -289,11 +289,24 @@ const IconTime = styled.span`
 `
 
 const GreenText = styled.div`
-  //
+  color: #27847a;
+  font: normal 400 18.4px/0 Roboto;
+  // font-family: Roboto;
+  // font-size: 18.4px;
+  // font-style: normal;
+  // font-weight: 400;
+  // line-height: 0px; /* 0% */
 `
 
 const GreenBoldText = styled.div`
-  //
+  color: #27847a;
+  font: normal 700 18.4px/0 Roboto;
+  margin: 26px 0 8px 0;
+  // font-family: Roboto;
+  // font-size: 18.4px;
+  // font-style: normal;
+  // font-weight: 700;
+  // line-height: 0px; /* 0% */
 `
 
 const Text = styled.div`

--- a/src/pages/components/CertificateViewDetails.js
+++ b/src/pages/components/CertificateViewDetails.js
@@ -27,7 +27,7 @@ export default function CertificateViewDetails({
   return (
     <PaddedWrapperDiv>
       <ContainerFlexWrapDiv>
-        {true == true && (
+        {hasEco2(eco2) && (
           <FullWidthDiv>
             <GreenText>Timestamp of Certificate Issuance</GreenText>
             <GreenBoldText>YYYY/MM/DD, HH:MM</GreenBoldText>
@@ -291,27 +291,24 @@ const IconTime = styled.span`
 const GreenText = styled.div`
   color: #27847a;
   font: normal 400 18.4px/0 Roboto;
-  // font-family: Roboto;
-  // font-size: 18.4px;
-  // font-style: normal;
-  // font-weight: 400;
-  // line-height: 0px; /* 0% */
+
+  @media (max-width: 1280px) {
+    font: normal 400 15.4px/0 Roboto;
+  }
 `
 
 const GreenBoldText = styled.div`
   color: #27847a;
   font: normal 700 18.4px/0 Roboto;
   margin: 26px 0 8px 0;
-  // font-family: Roboto;
-  // font-size: 18.4px;
-  // font-style: normal;
-  // font-weight: 700;
-  // line-height: 0px; /* 0% */
+
+  @media (max-width: 1280px) {
+    font: normal 700 15.4px/0 Roboto;
+  }
 `
 
 const Text = styled.div`
   display: flex;
-  width: 100%;
   height: 26px;
   min-width: 90px;
   font: 500 18px/26px Roboto;

--- a/src/pages/components/CertificateViewDetails.js
+++ b/src/pages/components/CertificateViewDetails.js
@@ -293,20 +293,12 @@ const IconTime = styled.span`
 const GreenText = styled.div`
   color: #27847a;
   font: normal 400 18.4px/0 Roboto;
-
-  @media (max-width: 1280px) {
-    font: normal 400 15.4px/0 Roboto;
-  }
 `
 
 const GreenBoldText = styled.div`
   color: #27847a;
   font: normal 700 18.4px/0 Roboto;
   margin: 26px 0 8px 0;
-
-  @media (max-width: 1280px) {
-    font: normal 700 15.4px/0 Roboto;
-  }
 `
 
 const Text = styled.div`

--- a/src/pages/components/CertificateViewDetails.js
+++ b/src/pages/components/CertificateViewDetails.js
@@ -16,6 +16,12 @@ const hasEco2 = (c) => c !== null && c !== undefined && isFinite(c) && c >= 0
 
 const convToKg = (g) => `${(g / 1000).toFixed(1)} kg`
 
+const formatDate = (date) =>
+  new Date(date).toLocaleString('en-GB', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  })
+
 export default function CertificateViewDetails({
   size,
   start,
@@ -23,6 +29,7 @@ export default function CertificateViewDetails({
   energy,
   eco2,
   posting,
+  timestamp,
 }) {
   return (
     <PaddedWrapperDiv>
@@ -30,7 +37,8 @@ export default function CertificateViewDetails({
         {hasEco2(eco2) && (
           <FullWidthDiv>
             <GreenText>Timestamp of Certificate Issuance</GreenText>
-            <GreenBoldText>YYYY/MM/DD, HH:MM</GreenBoldText>
+            {/* <GreenBoldText>YYYY/MM/DD, HH:MM</GreenBoldText> */}
+            <GreenBoldText>{formatDate(timestamp)}</GreenBoldText>
           </FullWidthDiv>
         )}
         {hasDate(start) && hasDate(end) && (
@@ -150,7 +158,6 @@ const PaddedWrapperDiv = styled.div`
 const FullWidthDiv = styled.div`
   margin: 8px 8px 20px 8px;
   width: 100%;
-  // background: #ededed;
 `
 
 const ContainerFlexWrapDiv = styled.div`

--- a/src/pages/components/CertificateViewDetails.js
+++ b/src/pages/components/CertificateViewDetails.js
@@ -4,6 +4,8 @@ import { Grid } from '@digicatapult/ui-component-library'
 
 import CertificateTimeInterval from './CertificateTimeInterval'
 
+import { formatDate } from '../../utils/helpers'
+
 import BgIconDateSVG from '../../assets/images/icon-date.svg'
 import BgIconTimeSVG from '../../assets/images/icon-time.svg'
 
@@ -15,12 +17,6 @@ const hasSize = (s) => s !== null && s !== undefined && isFinite(s) && s > 0
 const hasEco2 = (c) => c !== null && c !== undefined && isFinite(c) && c >= 0
 
 const convToKg = (g) => `${(g / 1000).toFixed(1)} kg`
-
-const formatDate = (date) =>
-  new Date(date).toLocaleString('en-GB', {
-    dateStyle: 'short',
-    timeStyle: 'short',
-  })
 
 export default function CertificateViewDetails({
   size,
@@ -37,7 +33,6 @@ export default function CertificateViewDetails({
         {hasEco2(eco2) && (
           <FullWidthDiv>
             <GreenText>Timestamp of Certificate Issuance</GreenText>
-            {/* <GreenBoldText>YYYY/MM/DD, HH:MM</GreenBoldText> */}
             <GreenBoldText>{formatDate(timestamp)}</GreenBoldText>
           </FullWidthDiv>
         )}


### PR DESCRIPTION
---
name: HYP 167 Cert Issued Timestamp
about: HYP 167 Certificate Issued Timestamp Inserted In The Cert Header
---

This is related to the **Jira** ticket **HYP-167**.

---

## Summary

All personas need to see a **`certificate issued`** timestamp on the certificate for **ISO 17065** compliance.

Currently not all the personas can see the timeline. We should add the certificate issued timestamp onto the certificate view.

Such as:

```
Timestamp of Certificate Issuance
2024/01/12, 22:50
```

AC: Add a textual timestamp of Certificate issuance on the certificate views for all personas; The presented timestamp should be the **`updated_at`**  timestamp (this is only for certificates with the issued state)

---

## Motivation

To make the GUI closer to the design.

---

## Describe alternatives you've considered

To place the entire code in a separate external component.

---

## Additional context

Draft design:

<img width="1598" alt="image" src="https://github.com/digicatapult/sqnc-hyproof-client/assets/58742260/885c733e-8cad-44f3-90f8-184b830721e6">

Screenshots:

![image](https://github.com/digicatapult/sqnc-hyproof-client/assets/58742260/f4f352b6-f492-4ea8-8897-5e0d6ab04e7e)

![image](https://github.com/digicatapult/sqnc-hyproof-client/assets/58742260/eb8e1e1c-69c7-4929-971a-41001b60fda3)

![output](https://github.com/digicatapult/sqnc-hyproof-client/assets/58742260/9336506e-31f2-4558-8346-dbd51a9d7926)

![output](https://github.com/digicatapult/sqnc-hyproof-client/assets/58742260/e695671d-a816-4b12-9d27-fa05416a125b)

---
