### PR TITLE
HYP 181 New Cert Btn Only for Heidi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.3.16",
+    "version": "0.3.17",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/sqnc-hyproof-client",
-            "version": "0.3.16",
+            "version": "0.3.17",
             "license": "Apache-2.0",
             "dependencies": {
                 "@digicatapult/ui-component-library": "^0.19.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.3.16",
+    "version": "0.3.17",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/sqnc-hyproof-client",
     "main": "src/index.js",

--- a/src/pages/CertificatesViewAll.js
+++ b/src/pages/CertificatesViewAll.js
@@ -134,7 +134,7 @@ export default function CertificatesViewAll() {
         {data?.length === 0 && 'nothing to render'}
       </Main>
       <Sidebar area="sidebar">
-        {persona.id == 'heidi' && (
+        {persona.id === 'heidi' && (
           <LargeButton variant="roundedPronounced">
             <Link to="/certificate?create=y">New Certificate</Link>
           </LargeButton>

--- a/src/pages/CertificatesViewAll.js
+++ b/src/pages/CertificatesViewAll.js
@@ -135,13 +135,10 @@ export default function CertificatesViewAll() {
       </Main>
       <Sidebar area="sidebar">
         {persona.id == 'heidi' && (
-          <>
-            <div>Button to go here</div>
-          </>
+          <LargeButton variant="roundedPronounced">
+            <Link to="/certificate?create=y">New Certificate!</Link>
+          </LargeButton>
         )}
-        <LargeButton variant="roundedPronounced">
-          <Link to="/certificate?create=y">New Certificate!</Link>
-        </LargeButton>
       </Sidebar>
     </>
   )

--- a/src/pages/CertificatesViewAll.js
+++ b/src/pages/CertificatesViewAll.js
@@ -134,8 +134,13 @@ export default function CertificatesViewAll() {
         {data?.length === 0 && 'nothing to render'}
       </Main>
       <Sidebar area="sidebar">
+        {persona.id == 'heidi' && (
+          <>
+            <div>Button to go here</div>
+          </>
+        )}
         <LargeButton variant="roundedPronounced">
-          <Link to="/certificate?create=y">New Certificate</Link>
+          <Link to="/certificate?create=y">New Certificate!</Link>
         </LargeButton>
       </Sidebar>
     </>

--- a/src/pages/CertificatesViewAll.js
+++ b/src/pages/CertificatesViewAll.js
@@ -136,7 +136,7 @@ export default function CertificatesViewAll() {
       <Sidebar area="sidebar">
         {persona.id == 'heidi' && (
           <LargeButton variant="roundedPronounced">
-            <Link to="/certificate?create=y">New Certificate!</Link>
+            <Link to="/certificate?create=y">New Certificate</Link>
           </LargeButton>
         )}
       </Sidebar>


### PR DESCRIPTION
---
name: New Cert Btn Only for Heidi
about: New Certificate Button Visible Only for Heidi
---

### Prerequisites

- [x] Checked the FAQs for common solutions: <https://github.com/digicatapult/sqnc-hyproof-client/blob/main/CONTRIBUTING.md/#FAQs>
- [x] Checked that your issue isn't already filed: <https://github.com/issues?utf8=✓&q=is%3Aissue+user%3Asqnc-hyproof-client>

---

### Description

This is connected to the **Jira** ticket **HYP-181**.

Heidi should be the only persona allowed to initiate/create a new certificate

At present the New Certificate button is available to all personas

---

### Steps to Reproduce

1. Start React
2. Got to **`/certificate`**
3. Switch from Heidi to Emma / Reginald / Connor

**Expected behaviour:**

The button should not be present on a view other than Emma's

**Actual behaviour:**

The button IS present on a view other than Emma's

**Reproduces how often:**

Always

---

### Versions

Not applicable

---

### Additional Information

**Alternatives considered**:

* One other alternative has been looked at, which is to remove the right panel all-together from the non-emma view but this option seem to work better.

**Screenshots**:

![output](https://github.com/digicatapult/sqnc-hyproof-client/assets/58742260/d95a079c-e8c8-4914-b907-eb0a37bc38d3)

---
