### PR TITLE
Clickable Area for New Certificate Button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.3.18",
+    "version": "0.3.19",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/sqnc-hyproof-client",
-            "version": "0.3.18",
+            "version": "0.3.19",
             "license": "Apache-2.0",
             "dependencies": {
                 "@digicatapult/ui-component-library": "^0.19.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.3.17",
+    "version": "0.3.18",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/sqnc-hyproof-client",
-            "version": "0.3.17",
+            "version": "0.3.18",
             "license": "Apache-2.0",
             "dependencies": {
                 "@digicatapult/ui-component-library": "^0.19.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.3.17",
+    "version": "0.3.18",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/sqnc-hyproof-client",
     "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.3.18",
+    "version": "0.3.19",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/sqnc-hyproof-client",
     "main": "src/index.js",

--- a/src/pages/CertificatesViewAll.js
+++ b/src/pages/CertificatesViewAll.js
@@ -135,8 +135,11 @@ export default function CertificatesViewAll() {
       </Main>
       <Sidebar area="sidebar">
         {persona.id === 'heidi' && (
-          <LargeButton variant="roundedPronounced">
-            <Link to="/certificate?create=y">New Certificate</Link>
+          <LargeButton
+            onClick={() => navigate('/certificate?create=y')}
+            variant="roundedPronounced"
+          >
+            New Certificate
           </LargeButton>
         )}
       </Sidebar>

--- a/src/pages/CertificatesViewAll.js
+++ b/src/pages/CertificatesViewAll.js
@@ -7,8 +7,6 @@ import {
   Button,
 } from '@digicatapult/ui-component-library'
 
-import { Link } from 'react-router-dom'
-
 import Nav from './components/Nav'
 import Header from './components/Header'
 import BgMoleculesImageSVG from '../assets/images/molecules-bg-repeat.svg'

--- a/src/pages/CertificatesViewAll.js
+++ b/src/pages/CertificatesViewAll.js
@@ -95,6 +95,7 @@ export default function CertificatesViewAll() {
 
   const persona = personas.find(({ id }) => id === current)
   const url = `${persona.origin}/v1/certificate`
+  const redirectToCreate = () => navigate('/certificate?create=y')
 
   React.useEffect(() => {
     if (!data) fetch({ url })
@@ -133,10 +134,7 @@ export default function CertificatesViewAll() {
       </Main>
       <Sidebar area="sidebar">
         {persona.id === 'heidi' && (
-          <LargeButton
-            onClick={() => navigate('/certificate?create=y')}
-            variant="roundedPronounced"
-          >
+          <LargeButton onClick={redirectToCreate} variant="roundedPronounced">
             New Certificate
           </LargeButton>
         )}


### PR DESCRIPTION
---
name: Clickable Area for New Certificate Button
about: Fixed The Clickable Area for Our Certificate Button on Heidi's View
---

### Prerequisites

- [x] Checked the FAQs for common solutions: <https://github.com/digicatapult/sqnc-hyproof-client/blob/main/CONTRIBUTING.md/#FAQs>
- [x] Checked that your issue isn't already filed: <https://github.com/issues?utf8=✓&q=is%3Aissue+user%3Asqnc-hyproof-client>

---

### Description

New certificate button, only the centre area of the button is clickable.

This is in relationship to the **JIRA** ticket **HYP-184**.

---

### Steps to Reproduce

1. Run the react GUI
2. Switch to view all certificates view
3. Switch to Heidi
4. Click on New Certificate ( the green area, not the text )

**Expected behaviour:**

Full clickable area

**Actual behaviour:**

Partial clickable area

**Reproduces how often:**

Always

---

### Versions

Not applicable

---

### Additional Information

![image](https://github.com/digicatapult/sqnc-hyproof-client/assets/58742260/5ade57ff-3765-4044-808c-cbb8aabf1481)

![image](https://github.com/digicatapult/sqnc-hyproof-client/assets/58742260/6147771b-2f23-4266-bd17-73ba43c1a077)

---
