### PR TITLE
Revoke split in two components and add the API calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/sqnc-hyproof-client",
-            "version": "0.4.3",
+            "version": "0.4.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "@digicatapult/ui-component-library": "^0.19.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/sqnc-hyproof-client",
-            "version": "0.5.0",
+            "version": "0.5.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@digicatapult/ui-component-library": "^0.19.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/sqnc-hyproof-client",
     "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/sqnc-hyproof-client",
     "main": "src/index.js",

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -72,7 +72,7 @@ export default function CertificateViewer() {
     const resChain = await callApi({ url, body })
     if (resChain?.state !== 'submitted') return
 
-    // StepThree - The Infinite GET Loop
+    // StepThree - The Periodical GET Check Loop
     url = `${origin}/v1/certificate/${id}`
     let isFinalised = false
     let res = null

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -53,7 +53,6 @@ export default function CertificateViewer() {
 
   // Functions
   const onRevoke = useCallback(async () => {
-    const id = data?.id
     let url, body
 
     setRevoking(true)
@@ -67,7 +66,7 @@ export default function CertificateViewer() {
 
     // StepTwo - The Second POST
     const fileId = resLocal?.id
-    url = `${origin}/v1/certificate/${id}/revocation`
+    url = `${origin}/v1/certificate/${data?.id}/revocation`
     body = { reason: fileId }
 
     setRevoking(false)

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -53,6 +53,7 @@ export default function CertificateViewer() {
 
   // Functions
   const onRevoke = useCallback(async () => {
+    const id = data?.id
     let url, body
 
     setRevoking(true)
@@ -62,14 +63,12 @@ export default function CertificateViewer() {
     body = reasonsDummyJSON
 
     const resLocal = await callApi({ url, body })
-    if (!resLocal || !resLocal?.ipfs_hash || resLocal?.id) return
+    if (!resLocal || !resLocal?.ipfs_hash || !resLocal?.id) return
 
-    const fileId = resLocal?.id
-
-    alert('File uploaded to IPFS. File ID: ' + fileId)
+    alert(id)
 
     setRevoking(false)
-  }, [origin, callApi])
+  }, [origin, callApi, data])
 
   // When mounted fetch every few secs and post co2 before that if Emma and co2 not set
   useEffect(() => {

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -269,7 +269,7 @@ export default function CertificateViewer() {
             <RevokeActionsButton
               handleRevoke={handleRevoke}
               disabled={data?.state !== 'issued'}
-              revoking={revoking}
+              loading={revoking}
             />
           )}
         </Sidebar>

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -1,4 +1,7 @@
 import React, { useRef, useState, useContext, useEffect } from 'react'
+
+import { useCallback } from 'react'
+
 import styled from 'styled-components'
 import { Timeline, Grid, Button } from '@digicatapult/ui-component-library'
 
@@ -22,6 +25,15 @@ import { TimelineDisclaimer } from './components/shared'
 const disclaimer =
   'Your certification status is dynamic and may change over time. Always refer to this page for the most up-to-date status.'
 
+const reasonsDummyJSON = {
+  predefinedReasons: {
+    0: { selection: null },
+    1: { selection: null },
+    2: { selection: null },
+  },
+  otherReason: '',
+}
+
 export default function CertificateViewer() {
   // Constants
   const { id } = useParams()
@@ -36,8 +48,28 @@ export default function CertificateViewer() {
   const [errorLast, setErrorLast] = useState('')
   const { callApiFn: fetchCert } = useAxios(false)
 
+  const { callApiFn: callApi } = useAxios(false)
+  const [revoking, setRevoking] = useState(false)
+
   // Functions
-  const onRevoke = () => alert('Revoke')
+  const onRevoke = useCallback(async () => {
+    let url, body
+
+    setRevoking(true)
+
+    // StepOne - The First POST
+    url = `${origin}/v1/attachment`
+    body = reasonsDummyJSON
+
+    const resLocal = await callApi({ url, body })
+    if (!resLocal || !resLocal?.ipfs_hash || resLocal?.id) return
+
+    const fileId = resLocal?.id
+
+    alert('File uploaded to IPFS. File ID: ' + fileId)
+
+    setRevoking(false)
+  }, [origin, callApi])
 
   // When mounted fetch every few secs and post co2 before that if Emma and co2 not set
   useEffect(() => {
@@ -225,7 +257,7 @@ export default function CertificateViewer() {
               disabled={data?.state === 'revoked'}
               variant="roundedPronounced"
             >
-              Revoke
+              Revoke {revoking && '...'}
             </LargeButton>
           )}
         </Sidebar>

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -272,7 +272,7 @@ export default function CertificateViewer() {
           {persona.id === 'reginald' && (
             <LargeButton
               onClick={onRevoke}
-              disabled={data?.state === 'revoked'}
+              disabled={data?.state !== 'issued'}
               variant="roundedPronounced"
             >
               Revoke {revoking && '...'}

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -47,7 +47,6 @@ export default function CertificateViewer() {
   // Functions
   const handleRevoke = useCallback(
     async (reasonsJSON) => {
-      alert('Revoke')
       let id = data?.original_token_id
       let url, body
 

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -84,7 +84,7 @@ export default function CertificateViewer() {
 
     // eslint-disable-next-line no-console
     console.log(JSON.stringify(await callApi({ url })))
-    alert(JSON.stringify(await callApi({ url })))
+    alert(`DONE! Certificate ID_${id} has been revoked.`)
 
     setRevoking(false)
   }, [origin, callApi, data])

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -68,6 +68,13 @@ export default function CertificateViewer() {
     const fileId = resLocal?.id
     url = `${origin}/v1/certificate/${data?.id}/revocation`
     body = { reason: fileId }
+    const resChain = await callApi({ url, body })
+
+    if (resChain?.state !== 'submitted') return
+
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(resChain))
+    alert(JSON.stringify(resChain))
 
     setRevoking(false)
   }, [origin, callApi, data])

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -22,6 +22,8 @@ import CertificateViewDetails from './components/CertificateViewDetails'
 import { formatDate } from '../utils/helpers'
 import { TimelineDisclaimer } from './components/shared'
 
+import RevokeActionsButton from './components/RevokeActionsButton'
+
 const disclaimer =
   'Your certification status is dynamic and may change over time. Always refer to this page for the most up-to-date status.'
 
@@ -88,6 +90,11 @@ export default function CertificateViewer() {
 
     setRevoking(false)
   }, [origin, callApi, data])
+
+  const handleRevoke = useCallback(async () => {
+    alert('Revoke')
+    onRevoke()
+  }, [onRevoke])
 
   // When mounted fetch every few secs and post co2 before that if Emma and co2 not set
   useEffect(() => {
@@ -269,7 +276,7 @@ export default function CertificateViewer() {
           </Paper>
         </MainContainer>
         <Sidebar area="sidebar">
-          {persona.id === 'reginald' && (
+          {/* {persona.id === 'reginald' && (
             <LargeButton
               onClick={onRevoke}
               disabled={data?.state !== 'issued'}
@@ -277,6 +284,12 @@ export default function CertificateViewer() {
             >
               Revoke {revoking && '...'}
             </LargeButton>
+          )} */}
+          {persona.id === 'reginald' && (
+            <RevokeActionsButton
+              handleRevoke={handleRevoke}
+              json={reasonsDummyJSON}
+            />
           )}
         </Sidebar>
       </MainWrapper>

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -353,20 +353,3 @@ const Paper = styled.div`
     width: 0;
   }
 `
-
-const LargeButton = styled(Button)`
-  min-height: 60px;
-  width: 100%;
-  font: normal 500 21px Roboto;
-  white-space: nowrap;
-  color: #33e58c;
-  border: 1px solid #2fe181;
-  background: #124338;
-  &:hover {
-    opacity: 0.6;
-  }
-  &:disabled {
-    color: #1c774a;
-    border: 1px solid #1c774a;
-  }
-`

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -265,15 +265,6 @@ export default function CertificateViewer() {
           </Paper>
         </MainContainer>
         <Sidebar area="sidebar">
-          {/* {persona.id === 'reginald' && (
-            <LargeButton
-              onClick={onRevoke}
-              disabled={data?.state !== 'issued'}
-              variant="roundedPronounced"
-            >
-              Revoke {revoking && '...'}
-            </LargeButton>
-          )} */}
           {persona.id === 'reginald' && (
             <RevokeActionsButton
               handleRevoke={handleRevoke}

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -3,7 +3,7 @@ import React, { useRef, useState, useContext, useEffect } from 'react'
 import { useCallback } from 'react'
 
 import styled from 'styled-components'
-import { Timeline, Grid, Button } from '@digicatapult/ui-component-library'
+import { Timeline, Grid } from '@digicatapult/ui-component-library'
 
 import Nav from './components/Nav'
 import Header from './components/Header'

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -65,7 +65,10 @@ export default function CertificateViewer() {
     const resLocal = await callApi({ url, body })
     if (!resLocal || !resLocal?.ipfs_hash || !resLocal?.id) return
 
-    alert(id)
+    // StepTwo - The Second POST
+    const fileId = resLocal?.id
+    url = `${origin}/v1/certificate/${id}/revocation`
+    body = { reason: fileId }
 
     setRevoking(false)
   }, [origin, callApi, data])

--- a/src/pages/components/RevokeActionsButton.js
+++ b/src/pages/components/RevokeActionsButton.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Button } from '@digicatapult/ui-component-library'
+
+const reasonsDummyJSON = {
+  predefinedReasons: {
+    0: { selection: null },
+    1: { selection: null },
+    2: { selection: null },
+  },
+  otherReason: '',
+}
+
+export default function RevokeActionsButton({
+  handleRevoke,
+  disabled,
+  revoking,
+}) {
+  const onClick = () => {
+    const answer = window.confirm('Reason for revoking?')
+    if (answer) {
+      handleRevoke(reasonsDummyJSON)
+    }
+  }
+
+  return (
+    <LargeButton
+      onClick={onClick}
+      disabled={disabled}
+      variant="roundedPronounced"
+    >
+      Revoke {revoking && '...'}
+    </LargeButton>
+  )
+}
+
+const LargeButton = styled(Button)`
+  min-height: 60px;
+  width: 100%;
+  font: normal 500 21px Roboto;
+  white-space: nowrap;
+  color: #33e58c;
+  border: 1px solid #2fe181;
+  background: #124338;
+  &:hover {
+    opacity: 0.6;
+  }
+  &:disabled {
+    color: #1c774a;
+    border: 1px solid #1c774a;
+  }
+`

--- a/src/pages/components/RevokeActionsButton.js
+++ b/src/pages/components/RevokeActionsButton.js
@@ -14,7 +14,7 @@ const reasonsDummyJSON = {
 export default function RevokeActionsButton({
   handleRevoke,
   disabled,
-  revoking: loading,
+  loading,
 }) {
   const onClick = () => {
     const answer = window.confirm('Reason for revoking?')

--- a/src/pages/components/RevokeActionsButton.js
+++ b/src/pages/components/RevokeActionsButton.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { keyframes } from 'styled-components'
 import { Button } from '@digicatapult/ui-component-library'
 
 const reasonsDummyJSON = {
@@ -14,7 +14,7 @@ const reasonsDummyJSON = {
 export default function RevokeActionsButton({
   handleRevoke,
   disabled,
-  revoking,
+  revoking: loading,
 }) {
   const onClick = () => {
     const answer = window.confirm('Reason for revoking?')
@@ -29,7 +29,8 @@ export default function RevokeActionsButton({
       disabled={disabled}
       variant="roundedPronounced"
     >
-      Revoke {revoking && '...'}
+      {!loading && 'Revoke '}
+      {loading && <AnimatedSpan>...</AnimatedSpan>}
     </LargeButton>
   )
 }
@@ -49,4 +50,21 @@ const LargeButton = styled(Button)`
     color: #1c774a;
     border: 1px solid #1c774a;
   }
+`
+
+const RevealAnimation = keyframes`
+  from {
+    width: 0px;
+  }
+  to {
+    width: 22px;
+  }
+`
+
+const AnimatedSpan = styled.span`
+  overflow: hidden;
+  display: inline-flex;
+  white-space: nowrap;
+  margin: 0 auto;
+  animation: ${RevealAnimation} 1s steps(4, end) infinite;
 `


### PR DESCRIPTION
---
name: Split into Multiple Components and Add Calls
about: Split The Revoke Action into Multiple Components and Add API Calls
---

## Summary

This splits the revoke action into multiple components and add api calls.

This pull request is strictly related to the **JIRA** ticket **HYP-142** or parts of it.

---

## Motivation

To make sure the React GUI is as close as possible to the Figma design.

---

## Describe alternatives you've considered

A more compact one-component solution.

---

## Additional context

The button becomes disabled if the cert is already revoked:

![image](https://github.com/digicatapult/sqnc-hyproof-client/assets/58742260/df5889ed-34be-4a31-b483-3393d5d1717f)

Flow:

![output](https://github.com/digicatapult/sqnc-hyproof-client/assets/58742260/aee8a445-756f-47af-9223-faedcf492115)

---
