### PR TITLE
HYP 199 Pop-up closes itself

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.5.16",
+    "version": "0.5.17",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/sqnc-hyproof-client",
-            "version": "0.5.16",
+            "version": "0.5.17",
             "license": "Apache-2.0",
             "dependencies": {
                 "@digicatapult/ui-component-library": "^0.19.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.5.14",
+    "version": "0.5.15",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/sqnc-hyproof-client",
-            "version": "0.5.14",
+            "version": "0.5.15",
             "license": "Apache-2.0",
             "dependencies": {
                 "@digicatapult/ui-component-library": "^0.19.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.5.14",
+    "version": "0.5.15",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/sqnc-hyproof-client",
     "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.5.16",
+    "version": "0.5.17",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/sqnc-hyproof-client",
     "main": "src/index.js",

--- a/src/hooks/use-axios.js
+++ b/src/hooks/use-axios.js
@@ -54,8 +54,7 @@ export default function useAxios(
   const { refetch: refetchApiFn } = useQuery({
     queryKey: [url],
     queryFn: useCallback(async () => {
-      const headers = { 'content-type': 'application/json' }
-      const options = [url, { headers }]
+      const options = [url, { headers: { 'content-type': 'application/json' } }]
       const method = 'get'
       try {
         const res = await axios[method](...options)

--- a/src/hooks/use-axios.js
+++ b/src/hooks/use-axios.js
@@ -8,7 +8,7 @@ import axios from 'axios'
 // Notes:
 // Can be used with useAxios(true, '...') for an automatic call on component mount.
 // Additionally, can be used with useAxios(false, '...') for a manual call.
-// Also, can also be used w/ { refetchApiFn } = useAxios(false, '...', url) for state-less call.
+// Also, can also be used w/ { refetchApiFn } = useAxios(false, '...', url) for stateless call.
 export default function useAxios(
   run = false,
   urlRun,

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -24,6 +24,16 @@ import RevokeActionsButton from './components/RevokeActionsButton'
 
 // import axios from 'axios'
 
+// import { useQuery } from '@tanstack/react-query'
+
+// const useAxiosCustom = (u) => {
+//   const { refetch } = useQuery({
+//     queryKey: [u],
+//     queryFn: () => fetch(u).then((res) => res.json()),
+//   })
+//   return { recallApiFn: refetch }
+// }
+
 const disclaimer =
   'Your certification status is dynamic and may change over time. Always refer to this page for the most up-to-date status.'
 
@@ -40,6 +50,8 @@ export default function CertificateViewer() {
   const [errorHash, setErrorHash] = useState('')
   const [errorLast, setErrorLast] = useState('')
   const { callApiFn: fetchCert } = useAxios(false)
+  const urlRefetch = `${origin}/v1/certificate/${id}`
+  const { refetchApiFn: refetch } = useAxios(false, '', '', '', '', urlRefetch)
 
   const { callApiFn: callApi } = useAxios(false)
   const [revoking, setRevoking] = useState(false)
@@ -90,9 +102,7 @@ export default function CertificateViewer() {
       let result = null
       try {
         // result = await fetchCert({ url: `${origin}/v1/certificate/${id}` })
-        result = await (await fetch(`${origin}/v1/certificate/${id}`)).json()
-        // const res = await axios['get'](`${origin}/v1/certificate/${id}`)
-        // result = res?.data
+        result = (await refetch()).data
       } catch (e) {
         setErrorLast(e)
       }
@@ -176,7 +186,7 @@ export default function CertificateViewer() {
       clearInterval(intervalId)
       setPosting(false)
     }
-  }, [curPersona, id, origin, context, fetchCert])
+  }, [curPersona, id, origin, context, fetchCert, refetch])
 
   const certificateDates = useMemo(() => {
     return (

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -38,8 +38,14 @@ export default function CertificateViewer() {
   const [errorHash, setErrorHash] = useState('')
   const [errorLast, setErrorLast] = useState('')
   const { callApiFn: fetchCert } = useAxios(false)
-  const urlRefetch = `${origin}/v1/certificate/${id}`
-  const { refetchApiFn: refetch } = useAxios(false, '', '', '', '', urlRefetch)
+  const { refetchApiFn: refetch } = useAxios(
+    false,
+    '',
+    '',
+    '',
+    '',
+    `${origin}/v1/certificate/${id}`
+  )
 
   const { callApiFn: callApi } = useAxios(false)
   const [revoking, setRevoking] = useState(false)

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -22,6 +22,8 @@ import { TimelineDisclaimer } from './components/shared'
 
 import RevokeActionsButton from './components/RevokeActionsButton'
 
+// import axios from 'axios'
+
 const disclaimer =
   'Your certification status is dynamic and may change over time. Always refer to this page for the most up-to-date status.'
 
@@ -87,7 +89,10 @@ export default function CertificateViewer() {
     const fetchLatestCert = async () => {
       let result = null
       try {
-        result = await fetchCert({ url: `${origin}/v1/certificate/${id}` })
+        // result = await fetchCert({ url: `${origin}/v1/certificate/${id}` })
+        result = await (await fetch(`${origin}/v1/certificate/${id}`)).json()
+        // const res = await axios['get'](`${origin}/v1/certificate/${id}`)
+        // result = res?.data
       } catch (e) {
         setErrorLast(e)
       }

--- a/src/pages/CertificateViewer.js
+++ b/src/pages/CertificateViewer.js
@@ -22,18 +22,6 @@ import { TimelineDisclaimer } from './components/shared'
 
 import RevokeActionsButton from './components/RevokeActionsButton'
 
-// import axios from 'axios'
-
-// import { useQuery } from '@tanstack/react-query'
-
-// const useAxiosCustom = (u) => {
-//   const { refetch } = useQuery({
-//     queryKey: [u],
-//     queryFn: () => fetch(u).then((res) => res.json()),
-//   })
-//   return { recallApiFn: refetch }
-// }
-
 const disclaimer =
   'Your certification status is dynamic and may change over time. Always refer to this page for the most up-to-date status.'
 
@@ -101,7 +89,6 @@ export default function CertificateViewer() {
     const fetchLatestCert = async () => {
       let result = null
       try {
-        // result = await fetchCert({ url: `${origin}/v1/certificate/${id}` })
         result = (await refetch()).data
       } catch (e) {
         setErrorLast(e)


### PR DESCRIPTION
---
name: Pop-up closes itself
about: What We Do pop-up closes itself after 2 secs on the single-certificate-view
---

### Prerequisites

- [x] Checked the FAQs for common solutions: <https://github.com/digicatapult/sqnc-hyproof-client/blob/main/CONTRIBUTING.md/#FAQs>
- [x] Checked that your issue isn't already filed: <https://github.com/issues?utf8=✓&q=is%3Aissue+user%3Asqnc-hyproof-client>

---

### Description

What We Do pop-up closes itself after 2 secs on the single-certificate-view

The about pop-up aka "What We Do" pop-up keeps on closing itself after 2 seconds on the single-certificate-view. This is due to the fact that there is an infinite loop and that loop changes state every 2 seconds causing the pop-up to re-render in its closed state.

---

### Steps to Reproduce

1. Ope the single certificate view of any certificate like id 1
2. Click on What We Do

**Expected behaviour:**

The pop up should stay open

**Actual behaviour:**

The pop up closes itself

**Reproduces how often:**

Always

---

### Versions

N/A

---

### Additional Information

**Before**:

![img](https://github.com/digicatapult/sqnc-hyproof-client/assets/58742260/42e2ab22-0262-4b20-b842-1af83dd10a46)

**After**:

![output](https://github.com/digicatapult/sqnc-hyproof-client/assets/58742260/494fb9d7-4e09-4986-ad47-301bdea3747b)

This is caused by the fact that the **`setInterval`** loop makes use of useAxios which in return updates the state in order to handle things like loading and handle things like grabbing error information.

One alternative conisdered is changing 

```js
    // Fetch latest certificate
    const fetchLatestCert = async () => {
      let result = null
      try {
        result = await fetchCert({ url: `${origin}/v1/certificate/${id}` })
      } catch (e) {
        setErrorLast(e)
      }
      if (!Object.keys(result).length) setErrorLast('404')
      if (Object.keys(result).length) return result
    }
```

To

```js
    // Fetch latest certificate
    const fetchLatestCert = async () => {
      let result = null
      try {
        result = await (await fetch(`${origin}/v1/certificate/${id}`)).json()
      } catch (e) {
        setErrorLast(e)
      }
      if (!Object.keys(result).length) setErrorLast('404')
      if (Object.keys(result).length) return result
    }
```

However this solution is not ideal and I have used a solution that uses the **`@tanstack/react-query`** library also because in all the other instances we are using _react-query_.

Added a new method that will use get to query the backend without using `useState` to prevent component re-render.

```js
result = (await refetch()).data
```

---
