### PR TITLE
Disabling Renovate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.5.3888",
+    "version": "0.5.38",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.5.37",
+    "version": "0.5.3888",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@digicatapult/sqnc-hyproof-client",
-            "version": "0.5.37",
+            "version": "0.5.38",
             "license": "Apache-2.0",
             "dependencies": {
                 "@digicatapult/ui-component-library": "^0.19.30",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@digicatapult/sqnc-hyproof-client",
-    "version": "0.5.37",
+    "version": "0.5.38",
     "description": "User interface for HyProof",
     "homepage": "https://github.com/digicatapult/sqnc-hyproof-client",
     "main": "src/index.js",

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["github>digicatapult/renovate-config"]
+	"extends": ["github>digicatapult/renovate-config"],
+	"enabled": false
 }


### PR DESCRIPTION
---
name: Disabling Renovate
about: Disabling The Renovate Bot
---

## Summary

Since all the other dependencies are likely to be upgraded to newer versions and since this project needs specific versions to work it has been decided: the Renovate Bot that automatically checks for dependency upgrades needs to be deactivated.

## Motivation

This PoC is close to become a finalised project -- ready to be demonstrated ( although not production code ).

## Describe alternatives you've considered

Considered stopping it from the Setting section inside the github UI.

## Additional context

N/A
